### PR TITLE
Major API refactoring and cleanup

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -64,8 +64,8 @@ for system errors so they can integrate cleanly with host I/O abstractions.
 ### Context Packet Fields (CIF System)
 - FieldProxy caches offset, size, presence on creation
 - Three-level access hierarchy:
-  - `.raw_bytes()` - on-wire bytes as-is
-  - `.raw_value()` - structured format (Q52.12, etc.)
+  - `.bytes()` - on-wire bytes as-is
+  - `.encoded()` - structured format (Q52.12, etc.)
   - `.value()` - interpreted values (Hz, dBm) - optional
 - Lazy evaluation - field not read until proxy dereferenced
 - Works for both compile-time and runtime packets

--- a/docs/header_view.md
+++ b/docs/header_view.md
@@ -1,0 +1,170 @@
+# Header View API
+
+The HeaderView API provides typed access to VRT packet header fields. All VRT packets contain a 32-bit header word as their first word, which encodes essential packet metadata.
+
+## Overview
+
+The header word contains packet metadata including type, size, timestamp format indicators, and packet-specific flags. The HeaderView classes provide a type-safe interface to these fields without manual bit manipulation.
+
+## Class Hierarchy
+
+```cpp
+HeaderView         // Read-only access (const)
+  └── MutableHeaderView  // Read-write access (inherits from HeaderView)
+```
+
+## Accessing Header Views
+
+Header views are obtained through packet accessors:
+
+| Packet Type | Non-const Method | Const Method |
+|-------------|------------------|--------------|
+| `DataPacket` | `header()` → `MutableHeaderView` | `header() const` → `HeaderView` |
+| `DataPacketView` | `header()` → `HeaderView` | — |
+| `ContextPacket` | `header()` → `MutableHeaderView` | `header() const` → `HeaderView` |
+| `ContextPacketView` | `header()` → `HeaderView` | — |
+
+## HeaderView Methods (Read-Only)
+
+### Core Fields
+
+| Method | Return Type | Description |
+|--------|-------------|-------------|
+| `packet_type()` | `PacketType` | 4-bit packet type field (bits 31-28) |
+| `packet_count()` | `uint8_t` | 4-bit sequence number 0-15 (bits 19-16) |
+| `packet_size()` | `uint16_t` | Packet size in 32-bit words (bits 15-0) |
+
+### Indicator Bits
+
+| Method | Return Type | Description |
+|--------|-------------|-------------|
+| `has_class_id()` | `bool` | Class ID indicator - C bit (bit 27) |
+| `has_trailer()` | `bool` | Trailer indicator - T bit (bit 26), data packets only |
+
+### Timestamp Format Indicators
+
+| Method | Return Type | Description |
+|--------|-------------|-------------|
+| `tsi_type()` | `TsiType` | Timestamp integer format type (bits 23-22) |
+| `tsf_type()` | `TsfType` | Timestamp fractional format type (bits 21-20) |
+| `has_timestamp_integer()` | `bool` | Convenience: TSI ≠ none |
+| `has_timestamp_fractional()` | `bool` | Convenience: TSF ≠ none |
+
+**Important**: These methods return metadata ABOUT timestamp formats, not the actual timestamp values. To access timestamp data, use the packet-level `timestamp()` or `timestamp_integer()`/`timestamp_fractional()` methods.
+
+### Packet-Type-Specific Indicators
+
+The header interprets bits 24-26 differently based on packet type. These methods return type-specific structs:
+
+| Method | Return Type | Applicable To | Description |
+|--------|-------------|---------------|-------------|
+| `data_indicators()` | `DataIndicators` | Data packets | Trailer/Spectrum/Nd0 flags |
+| `context_indicators()` | `ContextIndicators` | Context packets | TSM/Nd0 flags |
+| `command_indicators()` | `CommandIndicators` | Command packets | Ack/Cancel flags |
+
+## MutableHeaderView Methods (Write Access)
+
+MutableHeaderView inherits all read methods and adds:
+
+| Method | Parameters | Description |
+|--------|------------|-------------|
+| `set_packet_count(uint8_t)` | 0-15 | Set 4-bit sequence number |
+| `set_packet_size(uint16_t)` | words | Set packet size in 32-bit words |
+
+**Note**: Only packet count and size are mutable. Other header fields are determined by packet template parameters and cannot be changed after packet creation.
+
+## Indicator Structures
+
+### DataIndicators
+
+Returned by `header().data_indicators()` for data packets:
+
+```cpp
+struct DataIndicators {
+    bool has_trailer;      // Bit 26: T bit
+    bool has_spectrum;     // Bit 25: Spectrum field indicator
+    bool not_v49_0;        // Bit 24: Not a V49.0 packet indicator (Nd0)
+};
+```
+
+### ContextIndicators
+
+Returned by `header().context_indicators()` for context packets:
+
+```cpp
+struct ContextIndicators {
+    bool timestamp_mode;   // Bit 25: TSM bit (false=fine, true=coarse)
+    bool not_v49_0;       // Bit 24: Not a V49.0 packet indicator (Nd0)
+    // Bit 26 is reserved (must be 0) for context packets
+};
+```
+
+### CommandIndicators
+
+Returned by `header().command_indicators()` for command packets:
+
+```cpp
+struct CommandIndicators {
+    bool acknowledge;      // Bit 26: ACK bit
+    bool cancel;          // Bit 25: Cancel bit
+    // Bit 24 reserved
+};
+```
+
+## Usage Examples
+
+### Reading Header Fields
+
+```cpp
+// Compile-time packet
+DataPacket<...> packet(buffer.data());
+auto hdr = packet.header();
+uint8_t count = hdr.packet_count();
+bool has_trailer = hdr.data_indicators().has_trailer;
+
+// Runtime view
+DataPacketView view(rx_buffer, size);
+if (view.is_valid()) {
+    auto hdr = view.header();
+    PacketType type = hdr.packet_type();
+    uint16_t words = hdr.packet_size();
+}
+```
+
+### Modifying Header Fields
+
+```cpp
+DataPacket<...> packet(buffer.data());
+packet.header().set_packet_count(5);
+packet.header().set_packet_size(100); // 100 words = 400 bytes
+```
+
+### Checking Timestamp Presence
+
+```cpp
+// Check timestamp format metadata in header
+auto hdr = packet.header();
+if (hdr.has_timestamp_integer()) {
+    // Packet has integer timestamp component
+    TsiType format = hdr.tsi_type(); // UTC, GPS, etc.
+}
+
+// Access actual timestamp values via packet
+if constexpr (packet.has_timestamp) {
+    auto ts = packet.timestamp(); // Actual timestamp data
+}
+```
+
+## Implementation Notes
+
+- Header word is stored in network byte order (big-endian)
+- All bit manipulations handle endianness automatically
+- Packet count wraps modulo 16 (4-bit field)
+- Debug builds warn when `set_packet_count()` receives values > 15
+- Header views are lightweight (single pointer) and cheap to copy
+
+## See Also
+
+- [Packet Accessors](packet_accessors.md) - Packet-level API reference
+- [Trailer View API](trailer_view.md) - Trailer field access
+- VITA 49.2 Section 5.1.1 - Header word format specification

--- a/docs/style.md
+++ b/docs/style.md
@@ -14,10 +14,10 @@ Items not specified here should generally follow the C++ Core Guidelines
 ### Structure
 - `vrtio` - Main namespace for all public APIs
 - `vrtio::field` - Field tag definitions (kept flat for convenience)
+- `vrtio::cif`, `vrtio::trailer` - Narrow structs/enums kept separate for clarity
 - `vrtio::utils::fileio` - High-level I/O helpers (allocates, uses exceptions)
 - `vrtio::utils::netio` - UDP transport helpers (may allocate/throw)
 - `vrtio::utils::detail` - Shared iteration helpers (still considered internal)
-- `vrtio::cif`, `vrtio::trailer` - Narrow structs/enums kept separate for clarity
 - `vrtio::detail` - Implementation details (never access directly; anything not listed above should live here)
 
 

--- a/docs/trailer_view.md
+++ b/docs/trailer_view.md
@@ -1,0 +1,355 @@
+# Trailer View API
+
+The TrailerView API provides typed access to VRT packet trailer fields. The trailer is an optional 32-bit word that appears at the end of data packets to convey signal quality and status information.
+
+## Overview
+
+The trailer word contains status indicators and error flags related to signal processing and data validity. The TrailerView classes provide a type-safe interface to these fields following the VITA 49.2 enable/indicator bit pairing pattern.
+
+**Important**: Per VITA 49.2 specification:
+- Only **data packets** can have trailers
+- **Context packets** never have trailers (bit 26 is reserved and must be 0)
+- **Command packets** never have trailers
+
+## Class Hierarchy
+
+```cpp
+TrailerView              // Read-only access
+  └── MutableTrailerView // Read-write access (inherits from TrailerView)
+
+TrailerBuilder           // Value-type builder for composing trailer words
+```
+
+## Accessing Trailer Views
+
+Trailer views are obtained through packet's `trailer()` method when `HasTrailer == Trailer::included`:
+
+| Packet Type | Non-const Method | Const Method |
+|-------------|------------------|--------------|
+| `DataPacket<..., Trailer::included>` | `trailer()` → `MutableTrailerView` | `trailer() const` → `TrailerView` |
+| `DataPacketView` | — | `trailer()` → `optional<uint32_t>` (raw word only) |
+
+## Enable/Indicator Bit Pairing
+
+The VITA 49.2 trailer uses enable/indicator bit pairing for 8 named status fields:
+- **Enable bit** (bits 31-24): When set to 1, the corresponding indicator bit contains valid information
+- **Indicator bit** (bits 19-12): The actual status value (true/false)
+
+When an enable bit is 0, the corresponding indicator value is **undefined** and should not be used. Therefore, all named indicator getters return `std::optional<bool>`:
+- `std::nullopt` when enable bit is 0 (indicator not enabled/invalid)
+- `true` or `false` when enable bit is 1 (indicator enabled and valid)
+
+## TrailerView Methods (Read-Only)
+
+### Associated Context Packet Count
+
+| Method | Return Type | Description |
+|--------|-------------|-------------|
+| `context_packet_count()` | `std::optional<uint8_t>` | Returns count (0-127) if E bit is set, nullopt otherwise. Per Rule 5.1.6-13: When E=1, count is valid. When E=0, count is undefined. |
+
+### Named Indicators (Enable/Indicator Pairs)
+
+All named indicator methods return `std::optional<bool>`:
+- `std::nullopt` = enable bit is 0 (indicator not valid)
+- `true` = enable bit is 1, indicator bit is 1
+- `false` = enable bit is 1, indicator bit is 0
+
+| Method | Enable Bit | Indicator Bit | Description |
+|--------|-----------|---------------|-------------|
+| `calibrated_time()` | 31 | 19 | Calibrated time indicator |
+| `valid_data()` | 30 | 18 | Valid data indicator |
+| `reference_lock()` | 29 | 17 | Reference lock indicator |
+| `agc_mgc()` | 28 | 16 | AGC/MGC indicator |
+| `detected_signal()` | 27 | 15 | Detected signal indicator |
+| `spectral_inversion()` | 26 | 14 | Spectral inversion indicator |
+| `over_range()` | 25 | 13 | Over-range indicator |
+| `sample_loss()` | 24 | 12 | Sample loss indicator |
+
+### Sample Frame and User-Defined Fields
+
+These fields have no enable bits and always return `bool`:
+
+| Method | Bit | Description |
+|--------|-----|-------------|
+| `sample_frame_1()` | 11 | Sample frame bit 1 |
+| `sample_frame_0()` | 10 | Sample frame bit 0 |
+| `user_defined_1()` | 9 | User-defined bit 1 |
+| `user_defined_0()` | 8 | User-defined bit 0 |
+
+### Utility Methods
+
+| Method | Return Type | Description |
+|--------|-------------|-------------|
+| `raw()` | `uint32_t` | Entire trailer word value |
+
+## MutableTrailerView Methods (Write Access)
+
+MutableTrailerView inherits all read methods from TrailerView and adds:
+
+### Associated Context Packet Count
+
+| Method | Parameters | Description |
+|--------|------------|-------------|
+| `set_context_packet_count(uint8_t)` | count (0-127) | Sets E bit to 1 and count to specified value |
+| `clear_context_packet_count()` | — | Sets E bit to 0, making count invalid |
+
+### Named Indicator Setters
+
+Each setter **automatically sets both the enable bit and indicator bit**:
+
+| Method | Parameters | Description |
+|--------|------------|-------------|
+| `set_calibrated_time(bool)` | value | Sets enable bit 31 to 1, indicator bit 19 to value |
+| `set_valid_data(bool)` | value | Sets enable bit 30 to 1, indicator bit 18 to value |
+| `set_reference_lock(bool)` | value | Sets enable bit 29 to 1, indicator bit 17 to value |
+| `set_agc_mgc(bool)` | value | Sets enable bit 28 to 1, indicator bit 16 to value |
+| `set_detected_signal(bool)` | value | Sets enable bit 27 to 1, indicator bit 15 to value |
+| `set_spectral_inversion(bool)` | value | Sets enable bit 26 to 1, indicator bit 14 to value |
+| `set_over_range(bool)` | value | Sets enable bit 25 to 1, indicator bit 13 to value |
+| `set_sample_loss(bool)` | value | Sets enable bit 24 to 1, indicator bit 12 to value |
+
+### Named Indicator Clear Methods
+
+Each clear method **sets only the enable bit to 0** (indicator bit is left as-is but becomes invalid):
+
+| Method | Description |
+|--------|-------------|
+| `clear_calibrated_time()` | Sets enable bit 31 to 0 |
+| `clear_valid_data()` | Sets enable bit 30 to 0 |
+| `clear_reference_lock()` | Sets enable bit 29 to 0 |
+| `clear_agc_mgc()` | Sets enable bit 28 to 0 |
+| `clear_detected_signal()` | Sets enable bit 27 to 0 |
+| `clear_spectral_inversion()` | Sets enable bit 26 to 0 |
+| `clear_over_range()` | Sets enable bit 25 to 0 |
+| `clear_sample_loss()` | Sets enable bit 24 to 0 |
+
+### Sample Frame and User-Defined Setters
+
+| Method | Parameters | Description |
+|--------|------------|-------------|
+| `set_sample_frame_1(bool)` | value | Sets bit 11 |
+| `set_sample_frame_0(bool)` | value | Sets bit 10 |
+| `set_user_defined_1(bool)` | value | Sets bit 9 |
+| `set_user_defined_0(bool)` | value | Sets bit 8 |
+
+### Utility Methods
+
+| Method | Parameters | Description |
+|--------|------------|-------------|
+| `set_raw(uint32_t)` | value | Set entire trailer word |
+| `clear()` | — | Zero entire trailer word (all enable bits and indicator bits set to 0) |
+
+## TrailerBuilder API
+
+TrailerBuilder provides a fluent interface for composing trailer words:
+
+```cpp
+// Create a trailer with multiple fields set
+auto trailer_cfg = TrailerBuilder{}
+    .valid_data(true)              // Sets enable bit 30 and indicator bit 18
+    .calibrated_time(true)         // Sets enable bit 31 and indicator bit 19
+    .context_packet_count(3);      // Sets E bit 7 and count bits 6-0
+
+// Apply to a packet builder
+auto packet = PacketBuilder<PacketType>(buffer.data())
+    .stream_id(0x1234)
+    .trailer(trailer_cfg)
+    .build();
+```
+
+### Builder Methods
+
+All setter methods return `TrailerBuilder&` for chaining:
+
+| Method | Parameters | Description |
+|--------|------------|-------------|
+| `raw(uint32_t)` | value | Set entire word |
+| `clear()` | — | Zero entire word |
+| `context_packet_count(uint8_t)` | count | Set E bit and count (0-127) |
+| `calibrated_time(bool)` | value | Set enable bit 31 and indicator bit 19 |
+| `valid_data(bool)` | value | Set enable bit 30 and indicator bit 18 |
+| `reference_lock(bool)` | value | Set enable bit 29 and indicator bit 17 |
+| `agc_mgc(bool)` | value | Set enable bit 28 and indicator bit 16 |
+| `detected_signal(bool)` | value | Set enable bit 27 and indicator bit 15 |
+| `spectral_inversion(bool)` | value | Set enable bit 26 and indicator bit 14 |
+| `over_range(bool)` | value | Set enable bit 25 and indicator bit 13 |
+| `sample_loss(bool)` | value | Set enable bit 24 and indicator bit 12 |
+| `sample_frame_1(bool)` | value | Set bit 11 |
+| `sample_frame_0(bool)` | value | Set bit 10 |
+| `user_defined_1(bool)` | value | Set bit 9 |
+| `user_defined_0(bool)` | value | Set bit 8 |
+| `from_view(TrailerView)` | view | Copy from existing trailer |
+| `value()` | — | Get composed `uint32_t` |
+
+## Usage Examples
+
+### Reading Trailer Fields with Optional Handling
+
+```cpp
+// Compile-time packet with trailer
+using PacketType = SignalDataPacket<NoClassId, TimeStampUTC, Trailer::included, 128>;
+PacketType packet(buffer.data());
+
+// Check named indicators (returns std::optional<bool>)
+if (auto valid = packet.trailer().valid_data()) {
+    if (*valid) {
+        // Data is valid
+    } else {
+        // Data is explicitly marked invalid
+    }
+} else {
+    // Valid data indicator is not enabled (undefined)
+}
+
+// Check for errors
+if (auto over = packet.trailer().over_range()) {
+    if (*over) {
+        // Over-range error detected
+    }
+}
+if (auto loss = packet.trailer().sample_loss()) {
+    if (*loss) {
+        // Sample loss detected
+    }
+}
+
+// Check context packet count
+if (auto count = packet.trailer().context_packet_count()) {
+    std::cout << "Associated with " << (int)*count << " context packets\n";
+}
+
+// Sample frame and user-defined (always return bool)
+bool frame_bit = packet.trailer().sample_frame_1();
+```
+
+### Setting Trailer Fields
+
+```cpp
+// Set individual named indicators (automatically sets enable bit)
+packet.trailer().set_valid_data(true);        // Sets bits 30 and 18
+packet.trailer().set_calibrated_time(true);   // Sets bits 31 and 19
+packet.trailer().set_reference_lock(true);    // Sets bits 29 and 17
+
+// Set context packet count (automatically sets E bit)
+packet.trailer().set_context_packet_count(5);  // Sets bit 7 and bits 6-0 = 5
+
+// Clear individual indicators (sets only enable bit to 0)
+packet.trailer().clear_valid_data();           // Clears bit 30
+
+// Clear entire trailer
+packet.trailer().clear();                      // All bits = 0
+```
+
+### Using TrailerBuilder with PacketBuilder
+
+```cpp
+// Build packet with comprehensive status
+using PacketType = SignalDataPacket<NoClassId, TimeStampUTC, Trailer::included, 128>;
+std::vector<uint8_t> buffer(PacketType::size_bytes);
+
+// Compose trailer configuration
+auto good_status = TrailerBuilder{}
+    .valid_data(true)
+    .calibrated_time(true)
+    .reference_lock(true)
+    .context_packet_count(2);
+
+// Build packet
+auto ts = TimeStampUTC::from_components(1000000, 0);
+auto packet = PacketBuilder<PacketType>(buffer.data())
+    .stream_id(0x12345678)
+    .timestamp(ts)
+    .trailer(good_status)
+    .packet_count(0)
+    .build();
+
+// Verify
+assert(packet.trailer().valid_data() == true);
+assert(packet.trailer().context_packet_count() == 2);
+```
+
+### Error Condition Reporting
+
+```cpp
+// Report error conditions
+auto error_trailer = TrailerBuilder{}
+    .valid_data(false)    // Data not valid
+    .over_range(true)     // Over-range detected
+    .sample_loss(true);   // Sample loss detected
+
+auto packet = PacketBuilder<PacketType>(buffer.data())
+    .stream_id(0xAABBCCDD)
+    .trailer(error_trailer)
+    .build();
+
+// Check on receive
+if (packet.trailer().over_range().value_or(false) ||
+    packet.trailer().sample_loss().value_or(false)) {
+    std::cerr << "ERROR: Packet has errors\n";
+    if (packet.trailer().over_range().value_or(false)) {
+        std::cerr << "  - Over-range detected\n";
+    }
+    if (packet.trailer().sample_loss().value_or(false)) {
+        std::cerr << "  - Sample loss detected\n";
+    }
+}
+```
+
+### Inline Trailer Configuration
+
+```cpp
+// For simple cases, use PacketBuilder's trailer methods directly
+auto packet = PacketBuilder<PacketType>(buffer.data())
+    .stream_id(0x1234)
+    .trailer_valid_data(true)
+    .trailer_calibrated_time(true)
+    .trailer_context_packet_count(1)
+    .build();
+```
+
+## Bit Field Reference
+
+| Bits | Field | Description |
+|------|-------|-------------|
+| 31 | Calibrated Time Enable | Enable bit for calibrated time indicator |
+| 30 | Valid Data Enable | Enable bit for valid data indicator |
+| 29 | Reference Lock Enable | Enable bit for reference lock indicator |
+| 28 | AGC/MGC Enable | Enable bit for AGC/MGC indicator |
+| 27 | Detected Signal Enable | Enable bit for detected signal indicator |
+| 26 | Spectral Inversion Enable | Enable bit for spectral inversion indicator |
+| 25 | Over Range Enable | Enable bit for over-range indicator |
+| 24 | Sample Loss Enable | Enable bit for sample loss indicator |
+| 23-20 | Reserved | Must be zero |
+| 19 | Calibrated Time Indicator | Timestamp is calibrated |
+| 18 | Valid Data Indicator | Data is valid |
+| 17 | Reference Lock Indicator | Reference is locked |
+| 16 | AGC/MGC Indicator | AGC or MGC active |
+| 15 | Detected Signal Indicator | Signal detected |
+| 14 | Spectral Inversion Indicator | Spectral inversion present |
+| 13 | Over Range Indicator | Over-range occurred |
+| 12 | Sample Loss Indicator | Sample loss occurred |
+| 11 | Sample Frame 1 | Sample frame bit 1 |
+| 10 | Sample Frame 0 | Sample frame bit 0 |
+| 9 | User Defined 1 | User-defined bit 1 |
+| 8 | User Defined 0 | User-defined bit 0 |
+| 7 | E bit | Associated Context Packet Count Enable |
+| 6-0 | Context Packet Count | Associated context packet count (0-127) |
+
+## Implementation Notes
+
+- Trailer word is stored in network byte order (big-endian)
+- All bit manipulations handle endianness automatically
+- Context packet count is limited to 7 bits (0-127)
+- The E bit (bit 7) controls validity of context packet count (separate from indicator enable bits)
+- Enable bits (31-24) control validity of 8 named indicators (19-12)
+- Sample frame and user-defined fields (11-8) have no enable bits and are always valid
+- Trailer views are lightweight (single pointer) and cheap to copy
+- Using `value_or(false)` on optional indicators treats disabled indicators as false
+
+## See Also
+
+- [Packet Accessors](packet_accessors.md) - Packet-level API reference
+- [Header View API](header_view.md) - Header field access
+- VITA 49.2 Section 5.1.6 - Trailer word format specification
+- VITA 49.2 Table 5.1.6-1 - State and Event Indicator definitions
+- VITA 49.2 Rule 5.1.6-13 - E bit and Associated Context Packet Count

--- a/examples/context_example.cpp
+++ b/examples/context_example.cpp
@@ -34,7 +34,7 @@ void example_compile_time_context() {
     // Set signal parameters using interpreted values (Hz)
     packet[bandwidth].set_value(20'000'000.0);   // 20 MHz
     packet[sample_rate].set_value(10'000'000.0); // 10 MSPS
-    packet[gain].set_raw_value(0x00100000U);     // Gain value (raw format)
+    packet[gain].set_encoded(0x00100000U);       // Gain value (encoded format)
 
     // Device ID is 64-bit (OUI + device code)
     // For now we'll just set a simple value
@@ -45,7 +45,7 @@ void example_compile_time_context() {
     std::cout << "  Stream ID: 0x" << std::hex << packet.stream_id() << std::dec << "\n";
     std::cout << "  Bandwidth: " << packet[bandwidth].value() / 1'000'000.0 << " MHz\n";
     std::cout << "  Sample Rate: " << packet[sample_rate].value() / 1'000'000.0 << " MSPS\n";
-    std::cout << "  Gain: 0x" << std::hex << packet[gain].raw_value() << std::dec << "\n";
+    std::cout << "  Gain: 0x" << std::hex << packet[gain].encoded() << std::dec << "\n";
 }
 
 // Example 2: Creating a context packet with Class ID
@@ -170,7 +170,7 @@ void example_variable_fields() {
 
     // Use operator[] for GPS ASCII field
     if (auto gps_proxy = view[field::gps_ascii]) {
-        auto gps_data = gps_proxy.raw_bytes();
+        auto gps_data = gps_proxy.bytes();
         std::cout << "  GPS ASCII field size: " << gps_data.size() << " bytes\n";
 
         // Extract character count

--- a/examples/file_parsing_example.cpp
+++ b/examples/file_parsing_example.cpp
@@ -34,8 +34,8 @@ public:
             std::cout << "  Stream ID: " << (view.has_stream_id() ? "Yes" : "No") << "\n";
             std::cout << "  Class ID: " << (view.has_class_id() ? "Yes" : "No") << "\n";
             std::cout << "  Trailer: " << (view.has_trailer() ? "Yes" : "No") << "\n";
-            std::cout << "  TSI: " << static_cast<int>(view.tsi()) << "\n";
-            std::cout << "  TSF: " << static_cast<int>(view.tsf()) << "\n";
+            std::cout << "  TSI: " << static_cast<int>(view.tsi_type()) << "\n";
+            std::cout << "  TSF: " << static_cast<int>(view.tsf_type()) << "\n";
             std::cout << "  Count: " << static_cast<int>(view.packet_count()) << "\n";
         } else if (is_context_packet(pkt)) {
             const auto& view = std::get<ContextPacketView>(pkt);

--- a/examples/udp_reader_example.cpp
+++ b/examples/udp_reader_example.cpp
@@ -34,7 +34,7 @@ public:
      * @param pkt Type-safe packet variant (DataPacketView, ContextPacketView, or InvalidPacket)
      * @return true to continue processing, false to stop
      */
-    bool operator()(const utils::fileio::PacketVariant& pkt) {
+    bool operator()(const vrtio::PacketVariant& pkt) {
         packet_count_++;
 
         // Check global flag for graceful shutdown
@@ -45,7 +45,7 @@ public:
         std::cout << "\n=== Packet " << packet_count_ << " ===\n";
 
         // Process based on packet type
-        if (utils::fileio::is_data_packet(pkt)) {
+        if (vrtio::is_data_packet(pkt)) {
             const auto& view = std::get<DataPacketView>(pkt);
             data_packet_count_++;
 
@@ -64,7 +64,7 @@ public:
             std::cout << "  Packet Count: " << static_cast<int>(view.packet_count()) << "\n";
             std::cout << "  Payload Size: " << view.payload().size() << " bytes\n";
 
-        } else if (utils::fileio::is_context_packet(pkt)) {
+        } else if (vrtio::is_context_packet(pkt)) {
             const auto& view = std::get<ContextPacketView>(pkt);
             context_packet_count_++;
 
@@ -84,7 +84,7 @@ public:
 
         } else {
             // Invalid packet
-            const auto& invalid = std::get<utils::fileio::InvalidPacket>(pkt);
+            const auto& invalid = std::get<vrtio::InvalidPacket>(pkt);
             invalid_packet_count_++;
 
             std::cout << "Type: INVALID PACKET\n";

--- a/include/vrtio/detail/builder.hpp
+++ b/include/vrtio/detail/builder.hpp
@@ -151,11 +151,11 @@ public:
      * Set trailer context packets count
      * @param count Number of context packets (0-127)
      */
-    auto& trailer_context_packets(uint8_t count) noexcept
+    auto& trailer_context_packet_count(uint8_t count) noexcept
         requires HasTrailer<PacketType>
     {
         PacketType packet(buffer_, false); // Don't reinitialize
-        packet.trailer().set_context_packets(count);
+        packet.trailer().set_context_packet_count(count);
         return *this;
     }
 
@@ -195,29 +195,9 @@ public:
         return *this;
     }
 
-    /**
-     * Set trailer reference point indicator
-     * @param ref_point true if reference point is indicated
-     */
-    auto& trailer_reference_point(bool ref_point) noexcept
-        requires HasTrailer<PacketType>
-    {
-        PacketType packet(buffer_, false); // Don't reinitialize
-        packet.trailer().set_reference_point(ref_point);
-        return *this;
-    }
-
-    /**
-     * Set trailer signal detected indicator
-     * @param detected true if signal is detected
-     */
-    auto& trailer_signal_detected(bool detected) noexcept
-        requires HasTrailer<PacketType>
-    {
-        PacketType packet(buffer_, false); // Don't reinitialize
-        packet.trailer().set_signal_detected(detected);
-        return *this;
-    }
+    // NOTE: trailer_reference_point and trailer_signal_detected methods removed
+    // These were based on incorrect bit interpretations in the old API.
+    // Use the corrected indicator methods above instead.
 
     // Packet count (available for all packet types)
     auto& packet_count(uint8_t count) noexcept

--- a/include/vrtio/detail/header.hpp
+++ b/include/vrtio/detail/header.hpp
@@ -15,9 +15,9 @@ namespace vrtio {
  * - Bit 27: Class ID present
  * - Bits 26-24: Packet-specific indicator bits (interpretation depends on type)
  * - Bit 23: Reserved (must be 0)
- * - Bits 22-21: TSI type (2 bits)
- * - Bits 20-19: TSF type (2 bits)
- * - Bits 18-16: Reserved (must be 0)
+ * - Bits 23-22: TSI type (2 bits)
+ * - Bits 21-20: TSF type (2 bits)
+ * - Bits 19-16: Packet Count (4 bits)
  * - Bits 15-0: Packet size in words (16 bits)
  *
  * This is the single source of truth for all header bit manipulation.
@@ -51,13 +51,13 @@ inline constexpr uint8_t indicator_bit_24_shift = 24; // Spectrum/TSM/Cancel
 inline constexpr uint32_t indicator_bit_mask = 0x1;   // After shift (single bit)
 
 // ========================================================================
-// TSI Field (bits 22-21) - Integer Timestamp Type
+// TSI Field (bits 23-22) - Integer Timestamp Type
 // ========================================================================
 inline constexpr uint8_t tsi_shift = 22;
 inline constexpr uint32_t tsi_mask = 0x3; // After shift (2 bits)
 
 // ========================================================================
-// TSF Field (bits 20-19) - Fractional Timestamp Type
+// TSF Field (bits 21-20) - Fractional Timestamp Type
 // ========================================================================
 inline constexpr uint8_t tsf_shift = 20;
 inline constexpr uint32_t tsf_mask = 0x3; // After shift (2 bits)

--- a/include/vrtio/detail/header_indicators.hpp
+++ b/include/vrtio/detail/header_indicators.hpp
@@ -1,0 +1,96 @@
+#pragma once
+
+#include <cstdint>
+#include <vrtio/types.hpp>
+
+#include "header.hpp"
+#include "header_decode.hpp"
+
+namespace vrtio::detail {
+
+struct DataIndicators {
+    bool has_trailer = false;
+    bool spectrum = false;
+    bool nd0 = false;
+};
+
+struct ContextIndicators {
+    bool timestamp_mode = false;
+    bool nd0 = false;
+};
+
+struct CommandIndicators {
+    bool acknowledge = false;
+    bool cancel = false;
+};
+
+inline DataIndicators decode_data_indicators(uint32_t header_word) noexcept {
+    DataIndicators indicators{};
+    uint8_t type =
+        static_cast<uint8_t>((header_word >> header::packet_type_shift) & header::packet_type_mask);
+    if (type <= 3) {
+        indicators.has_trailer =
+            (header_word >> header::indicator_bit_26_shift) & header::indicator_bit_mask;
+        indicators.nd0 =
+            (header_word >> header::indicator_bit_25_shift) & header::indicator_bit_mask;
+        indicators.spectrum =
+            (header_word >> header::indicator_bit_24_shift) & header::indicator_bit_mask;
+    }
+    return indicators;
+}
+
+inline ContextIndicators decode_context_indicators(uint32_t header_word) noexcept {
+    ContextIndicators indicators{};
+    uint8_t type =
+        static_cast<uint8_t>((header_word >> header::packet_type_shift) & header::packet_type_mask);
+    if (type == 4 || type == 5) {
+        indicators.nd0 =
+            (header_word >> header::indicator_bit_25_shift) & header::indicator_bit_mask;
+        indicators.timestamp_mode =
+            (header_word >> header::indicator_bit_24_shift) & header::indicator_bit_mask;
+    }
+    return indicators;
+}
+
+inline CommandIndicators decode_command_indicators(uint32_t header_word) noexcept {
+    CommandIndicators indicators{};
+    uint8_t type =
+        static_cast<uint8_t>((header_word >> header::packet_type_shift) & header::packet_type_mask);
+    if (type == 6 || type == 7) {
+        indicators.acknowledge =
+            (header_word >> header::indicator_bit_26_shift) & header::indicator_bit_mask;
+        indicators.cancel =
+            (header_word >> header::indicator_bit_24_shift) & header::indicator_bit_mask;
+    }
+    return indicators;
+}
+
+inline DataIndicators decode_data_indicators(const DecodedHeader& header) noexcept {
+    DataIndicators indicators{};
+    if (static_cast<uint8_t>(header.type) <= 3) {
+        indicators.has_trailer = header.trailer_included;
+        indicators.spectrum = header.signal_spectrum;
+        indicators.nd0 = header.nd0;
+    }
+    return indicators;
+}
+
+inline ContextIndicators decode_context_indicators(const DecodedHeader& header) noexcept {
+    ContextIndicators indicators{};
+    if (header.type == PacketType::context || header.type == PacketType::extension_context) {
+        indicators.timestamp_mode = header.context_tsm;
+        indicators.nd0 = header.nd0;
+    }
+    return indicators;
+}
+
+inline CommandIndicators decode_command_indicators(const DecodedHeader& header) noexcept {
+    CommandIndicators indicators{};
+    if (header.type == PacketType::command || header.type == PacketType::extension_command) {
+        indicators.acknowledge = header.command_ack;
+        indicators.cancel = header.command_cancel;
+    }
+    return indicators;
+}
+
+} // namespace vrtio::detail

--- a/include/vrtio/detail/packet_header_accessor.hpp
+++ b/include/vrtio/detail/packet_header_accessor.hpp
@@ -1,0 +1,259 @@
+#pragma once
+
+#include <variant>
+
+#include <cstdint>
+#include <vrtio/types.hpp>
+
+#include "header.hpp"
+#include "header_decode.hpp"
+#include "header_indicators.hpp"
+
+namespace vrtio::detail {
+
+/**
+ * @brief Read-only accessor for VRT packet header word (first 32 bits)
+ *
+ * Provides a unified interface to access header fields from either:
+ * - A raw uint32_t word (for compile-time packets)
+ * - A decoded DecodedHeader struct (for runtime packet views)
+ *
+ * This class consolidates header field access and eliminates duplication
+ * between compile-time and runtime packet implementations.
+ */
+class HeaderView {
+protected:
+    // Tagged union - exactly one of these is active
+    std::variant<const uint32_t*, const DecodedHeader*> source_;
+
+    // Helper: extract packet type from raw word
+    static PacketType extract_packet_type(uint32_t word) noexcept {
+        return static_cast<PacketType>((word >> header::packet_type_shift) &
+                                       header::packet_type_mask);
+    }
+
+    // Helper: extract packet count from raw word
+    static uint8_t extract_packet_count(uint32_t word) noexcept {
+        return static_cast<uint8_t>((word >> header::packet_count_shift) &
+                                    header::packet_count_mask);
+    }
+
+    // Helper: extract packet size from raw word
+    static uint16_t extract_packet_size(uint32_t word) noexcept {
+        return static_cast<uint16_t>((word >> header::size_shift) & header::size_mask);
+    }
+
+    // Helper: extract class ID indicator from raw word
+    static bool extract_has_class_id(uint32_t word) noexcept {
+        return (word >> header::class_id_shift) & header::class_id_mask;
+    }
+
+    // Helper: extract TSI from raw word
+    static TsiType extract_tsi(uint32_t word) noexcept {
+        return static_cast<TsiType>((word >> header::tsi_shift) & header::tsi_mask);
+    }
+
+    // Helper: extract TSF from raw word
+    static TsfType extract_tsf(uint32_t word) noexcept {
+        return static_cast<TsfType>((word >> header::tsf_shift) & header::tsf_mask);
+    }
+
+public:
+    /**
+     * @brief Construct accessor from raw header word (compile-time packets)
+     */
+    explicit HeaderView(const uint32_t* header_word) noexcept : source_(header_word) {}
+
+    /**
+     * @brief Construct accessor from decoded header (runtime views)
+     */
+    explicit HeaderView(const DecodedHeader* decoded) noexcept : source_(decoded) {}
+
+    /**
+     * @brief Get packet type (4-bit field)
+     */
+    [[nodiscard]] PacketType packet_type() const noexcept {
+        if (auto decoded = std::get_if<const DecodedHeader*>(&source_)) {
+            return (*decoded)->type;
+        }
+        auto word = std::get<const uint32_t*>(source_);
+        return extract_packet_type(*word);
+    }
+
+    /**
+     * @brief Get packet count (4-bit sequence number)
+     */
+    [[nodiscard]] uint8_t packet_count() const noexcept {
+        if (auto decoded = std::get_if<const DecodedHeader*>(&source_)) {
+            return (*decoded)->packet_count;
+        }
+        auto word = std::get<const uint32_t*>(source_);
+        return extract_packet_count(*word);
+    }
+
+    /**
+     * @brief Get packet size in 32-bit words (16-bit field)
+     */
+    [[nodiscard]] uint16_t packet_size() const noexcept {
+        if (auto decoded = std::get_if<const DecodedHeader*>(&source_)) {
+            return (*decoded)->size_words;
+        }
+        auto word = std::get<const uint32_t*>(source_);
+        return extract_packet_size(*word);
+    }
+
+    /**
+     * @brief Check if class ID field is present (C bit)
+     */
+    [[nodiscard]] bool has_class_id() const noexcept {
+        if (auto decoded = std::get_if<const DecodedHeader*>(&source_)) {
+            return (*decoded)->has_class_id;
+        }
+        auto word = std::get<const uint32_t*>(source_);
+        return extract_has_class_id(*word);
+    }
+
+    /**
+     * @brief Check if trailer field is present (T bit, only valid for signal/ext data packets)
+     */
+    [[nodiscard]] bool has_trailer() const noexcept {
+        if (auto decoded = std::get_if<const DecodedHeader*>(&source_)) {
+            return decode_data_indicators(**decoded).has_trailer;
+        }
+        auto word = std::get<const uint32_t*>(source_);
+        return decode_data_indicators(*word).has_trailer;
+    }
+
+    /**
+     * @brief Get timestamp integer format type (TSI field, 2 bits)
+     *
+     * Returns the format of the integer timestamp component.
+     * This is metadata ABOUT the timestamp, not the timestamp data itself.
+     */
+    [[nodiscard]] TsiType tsi_type() const noexcept {
+        if (auto decoded = std::get_if<const DecodedHeader*>(&source_)) {
+            return (*decoded)->tsi;
+        }
+        auto word = std::get<const uint32_t*>(source_);
+        return extract_tsi(*word);
+    }
+
+    /**
+     * @brief Get timestamp fractional format type (TSF field, 2 bits)
+     *
+     * Returns the format of the fractional timestamp component.
+     * This is metadata ABOUT the timestamp, not the timestamp data itself.
+     */
+    [[nodiscard]] TsfType tsf_type() const noexcept {
+        if (auto decoded = std::get_if<const DecodedHeader*>(&source_)) {
+            return (*decoded)->tsf;
+        }
+        auto word = std::get<const uint32_t*>(source_);
+        return extract_tsf(*word);
+    }
+
+    /**
+     * @brief Check if integer timestamp component is present
+     *
+     * Derived from TSI field - true if TSI != none.
+     */
+    [[nodiscard]] bool has_timestamp_integer() const noexcept {
+        return tsi_type() != TsiType::none;
+    }
+
+    /**
+     * @brief Check if fractional timestamp component is present
+     *
+     * Derived from TSF field - true if TSF != none.
+     */
+    [[nodiscard]] bool has_timestamp_fractional() const noexcept {
+        return tsf_type() != TsfType::none;
+    }
+
+    /**
+     * @brief Get interpreted indicator bits for data packets (types 0-3)
+     */
+    [[nodiscard]] DataIndicators data_indicators() const noexcept {
+        if (auto decoded = std::get_if<const DecodedHeader*>(&source_)) {
+            return decode_data_indicators(**decoded);
+        }
+        auto word = std::get<const uint32_t*>(source_);
+        return decode_data_indicators(*word);
+    }
+
+    /**
+     * @brief Get interpreted indicator bits for context packets (types 4-5)
+     */
+    [[nodiscard]] ContextIndicators context_indicators() const noexcept {
+        if (auto decoded = std::get_if<const DecodedHeader*>(&source_)) {
+            return decode_context_indicators(**decoded);
+        }
+        auto word = std::get<const uint32_t*>(source_);
+        return decode_context_indicators(*word);
+    }
+
+    /**
+     * @brief Get interpreted indicator bits for command packets (types 6-7)
+     */
+    [[nodiscard]] CommandIndicators command_indicators() const noexcept {
+        if (auto decoded = std::get_if<const DecodedHeader*>(&source_)) {
+            return decode_command_indicators(**decoded);
+        }
+        auto word = std::get<const uint32_t*>(source_);
+        return decode_command_indicators(*word);
+    }
+};
+
+/**
+ * @brief Mutable accessor for VRT packet header word (compile-time packets only)
+ *
+ * Extends HeaderView with setter methods for modifying header fields.
+ * Only available for compile-time packets that operate on raw buffer words.
+ */
+class MutableHeaderView : public HeaderView {
+    uint32_t* mutable_word_; // Separate mutable pointer for setters
+
+    // Helper: update packet count in raw word
+    static void update_packet_count(uint32_t& word, uint8_t count) noexcept {
+        word = (word & ~(header::packet_count_mask << header::packet_count_shift)) |
+               ((count & header::packet_count_mask) << header::packet_count_shift);
+    }
+
+    // Helper: update packet size in raw word
+    static void update_packet_size(uint32_t& word, uint16_t size) noexcept {
+        word = (word & ~(header::size_mask << header::size_shift)) |
+               ((size & header::size_mask) << header::size_shift);
+    }
+
+public:
+    /**
+     * @brief Construct mutable accessor from raw header word
+     *
+     * Only available for compile-time packets. Runtime views are always const.
+     */
+    explicit MutableHeaderView(uint32_t* header_word) noexcept
+        : HeaderView(const_cast<const uint32_t*>(header_word)),
+          mutable_word_(header_word) {}
+
+    /**
+     * @brief Set packet count (4-bit sequence number)
+     */
+    void set_packet_count(uint8_t count) noexcept { update_packet_count(*mutable_word_, count); }
+
+    /**
+     * @brief Set packet size in 32-bit words (16-bit field)
+     */
+    void set_packet_size(uint16_t size) noexcept { update_packet_size(*mutable_word_, size); }
+
+    // Note: Other setters (packet_type, class_id, tsi, tsf, etc.) are typically set
+    // during packet construction and don't need to be modified afterward.
+    // If needed, they can be added following the same pattern.
+};
+
+} // namespace vrtio::detail
+
+// Public aliases
+namespace vrtio {
+using HeaderView = detail::HeaderView;
+using MutableHeaderView = detail::MutableHeaderView;
+} // namespace vrtio

--- a/include/vrtio/detail/packet_variant.hpp
+++ b/include/vrtio/detail/packet_variant.hpp
@@ -4,12 +4,12 @@
 #include <string>
 #include <variant>
 
-#include "../../detail/context_packet_view.hpp"
-#include "../../detail/data_packet_view.hpp"
-#include "../../detail/header_decode.hpp"
-#include "../../types.hpp"
+#include "../types.hpp"
+#include "context_packet_view.hpp"
+#include "data_packet_view.hpp"
+#include "header_decode.hpp"
 
-namespace vrtio::utils::fileio {
+namespace vrtio {
 
 /**
  * @brief Error result when a packet fails validation
@@ -33,15 +33,14 @@ struct InvalidPacket {
 /**
  * @brief Type-safe variant holding all possible validated packet views
  *
- * After reading a packet from a file, it will be parsed and validated,
- * then returned as one of:
+ * After parsing a packet, it will be validated and returned as one of:
  * - DataPacketView: Signal or Extension data packets (types 0-3)
  * - ContextPacketView: Context or Extension Context packets (types 4-5)
  * - InvalidPacket: Validation failed or unsupported packet type (types 6-7)
  */
-using PacketVariant = std::variant<vrtio::DataPacketView,    // Signal/Extension data packets
-                                   vrtio::ContextPacketView, // Context/Extension context packets
-                                   InvalidPacket // Validation failed or unsupported type
+using PacketVariant = std::variant<DataPacketView,    // Signal/Extension data packets
+                                   ContextPacketView, // Context/Extension context packets
+                                   InvalidPacket      // Validation failed or unsupported type
                                    >;
 
 /**
@@ -63,9 +62,9 @@ inline PacketType packet_type(const PacketVariant& pkt) noexcept {
         [](auto&& p) -> PacketType {
             using T = std::decay_t<decltype(p)>;
 
-            if constexpr (std::is_same_v<T, vrtio::DataPacketView>) {
+            if constexpr (std::is_same_v<T, DataPacketView>) {
                 return p.type();
-            } else if constexpr (std::is_same_v<T, vrtio::ContextPacketView>) {
+            } else if constexpr (std::is_same_v<T, ContextPacketView>) {
                 // ContextPacketView doesn't expose type(), so we need to infer it
                 // Context packets are always type 4 or 5
                 // We can't tell which without accessing internals, so default to 4
@@ -90,9 +89,9 @@ inline std::optional<uint32_t> stream_id(const PacketVariant& pkt) noexcept {
         [](auto&& p) -> std::optional<uint32_t> {
             using T = std::decay_t<decltype(p)>;
 
-            if constexpr (std::is_same_v<T, vrtio::DataPacketView>) {
+            if constexpr (std::is_same_v<T, DataPacketView>) {
                 return p.stream_id();
-            } else if constexpr (std::is_same_v<T, vrtio::ContextPacketView>) {
+            } else if constexpr (std::is_same_v<T, ContextPacketView>) {
                 return p.stream_id();
             }
 
@@ -107,7 +106,7 @@ inline std::optional<uint32_t> stream_id(const PacketVariant& pkt) noexcept {
  * @return true if the packet is a DataPacketView, false otherwise
  */
 inline bool is_data_packet(const PacketVariant& pkt) noexcept {
-    return std::holds_alternative<vrtio::DataPacketView>(pkt);
+    return std::holds_alternative<DataPacketView>(pkt);
 }
 
 /**
@@ -116,7 +115,7 @@ inline bool is_data_packet(const PacketVariant& pkt) noexcept {
  * @return true if the packet is a ContextPacketView, false otherwise
  */
 inline bool is_context_packet(const PacketVariant& pkt) noexcept {
-    return std::holds_alternative<vrtio::ContextPacketView>(pkt);
+    return std::holds_alternative<ContextPacketView>(pkt);
 }
 
-} // namespace vrtio::utils::fileio
+} // namespace vrtio

--- a/include/vrtio/detail/prologue.hpp
+++ b/include/vrtio/detail/prologue.hpp
@@ -64,9 +64,9 @@ public:
     static constexpr size_t timestamp_words = tsi_words + tsf_words;
 
     // Total prologue size
-    static constexpr size_t total_words =
+    static constexpr size_t size_words =
         header_words + stream_id_words + class_id_words + timestamp_words;
-    static constexpr size_t total_bytes = total_words * vrt_word_size;
+    static constexpr size_t size_bytes = size_words * vrt_word_size;
 
     // Field offsets in words (from start of packet)
     static constexpr size_t header_offset = 0;
@@ -141,6 +141,24 @@ public:
      */
     [[nodiscard]] uint32_t header() const noexcept {
         return detail::read_u32(buffer_, header_offset * vrt_word_size);
+    }
+
+    /**
+     * @brief Get reference to raw header word (mutable)
+     *
+     * Used by MutableHeaderView for direct manipulation.
+     */
+    [[nodiscard]] uint32_t& header_word() noexcept {
+        return *reinterpret_cast<uint32_t*>(buffer_ + header_offset * vrt_word_size);
+    }
+
+    /**
+     * @brief Get reference to raw header word (const)
+     *
+     * Used by HeaderView for reading.
+     */
+    [[nodiscard]] const uint32_t& header_word() const noexcept {
+        return *reinterpret_cast<const uint32_t*>(buffer_ + header_offset * vrt_word_size);
     }
 
     /**

--- a/include/vrtio/detail/trailer.hpp
+++ b/include/vrtio/detail/trailer.hpp
@@ -4,71 +4,87 @@
 
 namespace vrtio::trailer {
 
-// VITA 49.2 Trailer field bit positions
-// The trailer is a 32-bit word with various status and indicator fields
+// VITA 49.2 Section 5.1.6 Trailer field bit positions
+// The trailer is a 32-bit word with enable/indicator bit pairing
 
-// Bits 0-6: Associated Context Packets Count (7 bits)
-inline constexpr uint32_t context_packets_shift = 0;
-inline constexpr uint32_t context_packets_mask = 0x7F; // 7 bits
+// ============================================================================
+// Bits 0-6: Associated Context Packet Count (7 bits, range 0-127)
+// Bit 7: E bit (Associated Context Packet Count Enable)
+// ============================================================================
+inline constexpr uint32_t context_packet_count_shift = 0;
+inline constexpr uint32_t context_packet_count_mask = 0x7F; // 7 bits (bits 0-6)
+inline constexpr uint32_t e_bit = 7;                        // Enable bit for context packet count
 
-// Bit 7: Reserved
-inline constexpr uint32_t reserved1_bit = 7;
+// ============================================================================
+// Bits 8-11: User-Defined and Sample Frame Indicators
+// ============================================================================
+inline constexpr uint32_t user_defined_0_bit = 8;
+inline constexpr uint32_t user_defined_1_bit = 9;
+inline constexpr uint32_t sample_frame_0_bit = 10;
+inline constexpr uint32_t sample_frame_1_bit = 11;
 
-// Bit 8: Reference Lock
-inline constexpr uint32_t reference_lock_bit = 8;
+// ============================================================================
+// Bits 12-19: Indicator Bits (for 8 named state/event indicators)
+// ============================================================================
+inline constexpr uint32_t sample_loss_indicator_bit = 12;
+inline constexpr uint32_t over_range_indicator_bit = 13;
+inline constexpr uint32_t spectral_inversion_indicator_bit = 14;
+inline constexpr uint32_t detected_signal_indicator_bit = 15;
+inline constexpr uint32_t agc_mgc_indicator_bit = 16;
+inline constexpr uint32_t reference_lock_indicator_bit = 17;
+inline constexpr uint32_t valid_data_indicator_bit = 18;
+inline constexpr uint32_t calibrated_time_indicator_bit = 19;
 
-// Bit 9: AGC/MGC (Automatic/Manual Gain Control)
-inline constexpr uint32_t agc_mgc_bit = 9;
+// ============================================================================
+// Bits 24-31: Enable Bits (for 8 named state/event indicators)
+// These are separate from the E bit (bit 7) for context packet count
+// ============================================================================
+inline constexpr uint32_t sample_loss_enable_bit = 24;
+inline constexpr uint32_t over_range_enable_bit = 25;
+inline constexpr uint32_t spectral_inversion_enable_bit = 26;
+inline constexpr uint32_t detected_signal_enable_bit = 27;
+inline constexpr uint32_t agc_mgc_enable_bit = 28;
+inline constexpr uint32_t reference_lock_enable_bit = 29;
+inline constexpr uint32_t valid_data_enable_bit = 30;
+inline constexpr uint32_t calibrated_time_enable_bit = 31;
 
-// Bit 10: Detected Signal
-inline constexpr uint32_t detected_signal_bit = 10;
-
-// Bit 11: Spectral Inversion
-inline constexpr uint32_t spectral_inversion_bit = 11;
-
-// Bit 12: Over-range
-inline constexpr uint32_t over_range_bit = 12;
-
-// Bit 13: Sample Loss
-inline constexpr uint32_t sample_loss_bit = 13;
-
-// Bits 14-15: Reserved
-inline constexpr uint32_t reserved2_shift = 14;
-inline constexpr uint32_t reserved2_mask = 0x03; // 2 bits
-
-// Bit 16: Calibrated Time Indicator
-inline constexpr uint32_t calibrated_time_bit = 16;
-
-// Bit 17: Valid Data Indicator
-inline constexpr uint32_t valid_data_bit = 17;
-
-// Bit 18: Reference Point Indicator
-inline constexpr uint32_t reference_point_bit = 18;
-
-// Bit 19: Signal Detected
-inline constexpr uint32_t signal_detected_bit = 19;
-
-// Bits 20-31: Reserved
-inline constexpr uint32_t reserved3_shift = 20;
-inline constexpr uint32_t reserved3_mask = 0xFFF; // 12 bits
-
+// ============================================================================
 // Bit masks for direct manipulation
-inline constexpr uint32_t reference_lock_mask = 1U << reference_lock_bit;
-inline constexpr uint32_t agc_mgc_mask = 1U << agc_mgc_bit;
-inline constexpr uint32_t detected_signal_mask = 1U << detected_signal_bit;
-inline constexpr uint32_t spectral_inversion_mask = 1U << spectral_inversion_bit;
-inline constexpr uint32_t over_range_mask = 1U << over_range_bit;
-inline constexpr uint32_t sample_loss_mask = 1U << sample_loss_bit;
-inline constexpr uint32_t calibrated_time_mask = 1U << calibrated_time_bit;
-inline constexpr uint32_t valid_data_mask = 1U << valid_data_bit;
-inline constexpr uint32_t reference_point_mask = 1U << reference_point_bit;
-inline constexpr uint32_t signal_detected_mask = 1U << signal_detected_bit;
+// ============================================================================
 
-// Common status combinations
-inline constexpr uint32_t status_all_good = valid_data_mask | calibrated_time_mask;
-inline constexpr uint32_t status_errors = over_range_mask | sample_loss_mask;
+// E bit and context packet count
+inline constexpr uint32_t e_bit_mask = 1U << e_bit;
 
+// User-Defined and Sample Frame
+inline constexpr uint32_t user_defined_0_mask = 1U << user_defined_0_bit;
+inline constexpr uint32_t user_defined_1_mask = 1U << user_defined_1_bit;
+inline constexpr uint32_t sample_frame_0_mask = 1U << sample_frame_0_bit;
+inline constexpr uint32_t sample_frame_1_mask = 1U << sample_frame_1_bit;
+
+// Indicator bits
+inline constexpr uint32_t sample_loss_indicator_mask = 1U << sample_loss_indicator_bit;
+inline constexpr uint32_t over_range_indicator_mask = 1U << over_range_indicator_bit;
+inline constexpr uint32_t spectral_inversion_indicator_mask = 1U
+                                                              << spectral_inversion_indicator_bit;
+inline constexpr uint32_t detected_signal_indicator_mask = 1U << detected_signal_indicator_bit;
+inline constexpr uint32_t agc_mgc_indicator_mask = 1U << agc_mgc_indicator_bit;
+inline constexpr uint32_t reference_lock_indicator_mask = 1U << reference_lock_indicator_bit;
+inline constexpr uint32_t valid_data_indicator_mask = 1U << valid_data_indicator_bit;
+inline constexpr uint32_t calibrated_time_indicator_mask = 1U << calibrated_time_indicator_bit;
+
+// Enable bits
+inline constexpr uint32_t sample_loss_enable_mask = 1U << sample_loss_enable_bit;
+inline constexpr uint32_t over_range_enable_mask = 1U << over_range_enable_bit;
+inline constexpr uint32_t spectral_inversion_enable_mask = 1U << spectral_inversion_enable_bit;
+inline constexpr uint32_t detected_signal_enable_mask = 1U << detected_signal_enable_bit;
+inline constexpr uint32_t agc_mgc_enable_mask = 1U << agc_mgc_enable_bit;
+inline constexpr uint32_t reference_lock_enable_mask = 1U << reference_lock_enable_bit;
+inline constexpr uint32_t valid_data_enable_mask = 1U << valid_data_enable_bit;
+inline constexpr uint32_t calibrated_time_enable_mask = 1U << calibrated_time_enable_bit;
+
+// ============================================================================
 // Helper functions for bit manipulation
+// ============================================================================
 
 /**
  * Extract a single bit value from a trailer word
@@ -96,6 +112,18 @@ constexpr uint32_t set_bit(uint32_t value, bool bit_value) noexcept {
 }
 
 /**
+ * Clear a single bit in a trailer word
+ * @tparam Bit The bit position (0-31)
+ * @param value The trailer word value
+ * @return Updated trailer word with bit cleared
+ */
+template <uint32_t Bit>
+constexpr uint32_t clear_bit(uint32_t value) noexcept {
+    static_assert(Bit < 32, "Bit position must be less than 32");
+    return value & ~(1U << Bit);
+}
+
+/**
  * Extract a multi-bit field from a trailer word
  * @tparam Shift The starting bit position
  * @tparam Mask The bit mask (after shifting)
@@ -120,42 +148,16 @@ constexpr uint32_t set_field(uint32_t value, uint32_t field_value) noexcept {
     return (value & ~(Mask << Shift)) | ((field_value & Mask) << Shift);
 }
 
-// Inline helper functions for common operations
-
 /**
- * Check if the trailer indicates valid data
+ * Clear a multi-bit field in a trailer word
+ * @tparam Shift The starting bit position
+ * @tparam Mask The bit mask (after shifting)
+ * @param value The trailer word value
+ * @return Updated trailer word with field cleared
  */
-inline constexpr bool is_valid_data(uint32_t trailer) noexcept {
-    return extract_bit<valid_data_bit>(trailer);
-}
-
-/**
- * Check if the trailer indicates calibrated time
- */
-inline constexpr bool is_calibrated_time(uint32_t trailer) noexcept {
-    return extract_bit<calibrated_time_bit>(trailer);
-}
-
-/**
- * Check if the trailer indicates any error conditions
- */
-inline constexpr bool has_errors(uint32_t trailer) noexcept {
-    return (trailer & status_errors) != 0;
-}
-
-/**
- * Extract the associated context packets count
- */
-inline constexpr uint8_t extract_context_packets(uint32_t trailer) noexcept {
-    return static_cast<uint8_t>(
-        extract_field<context_packets_shift, context_packets_mask>(trailer));
-}
-
-/**
- * Create a trailer word with common good status
- */
-inline constexpr uint32_t create_good_status() noexcept {
-    return status_all_good;
+template <uint32_t Shift, uint32_t Mask>
+constexpr uint32_t clear_field(uint32_t value) noexcept {
+    return value & ~(Mask << Shift);
 }
 
 } // namespace vrtio::trailer

--- a/include/vrtio/detail/trailer_view.hpp
+++ b/include/vrtio/detail/trailer_view.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <optional>
+
 #include <cstdint>
 #include <cstring>
 
@@ -9,154 +11,384 @@
 namespace vrtio {
 
 /**
- * Immutable view over a trailer word stored in network byte order.
+ * Read-only view over a trailer word stored in network byte order.
  *
- * The view performs endian conversion on access and exposes typed getters
- * for each of the defined trailer fields.
+ * The trailer implements VITA 49.2 Section 5.1.6 with enable/indicator bit pairing.
+ * Each of the 8 named indicators has an enable bit (31-24) and an indicator bit (19-12).
+ * When the enable bit is 0, the indicator value is undefined/invalid.
  */
-class ConstTrailerView {
+class TrailerView {
 public:
-    explicit ConstTrailerView(const uint8_t* word_ptr) noexcept : word_ptr_(word_ptr) {}
+    explicit TrailerView(const uint8_t* word_ptr) noexcept : word_ptr_(word_ptr) {}
 
+    /**
+     * Get raw trailer word value (host byte order)
+     */
     uint32_t raw() const noexcept {
         uint32_t value;
         std::memcpy(&value, word_ptr_, sizeof(value));
         return detail::network_to_host32(value);
     }
 
-    uint8_t context_packets() const noexcept { return trailer::extract_context_packets(raw()); }
+    // ========================================================================
+    // Associated Context Packet Count (Rule 5.1.6-13)
+    // ========================================================================
 
-    bool reference_lock() const noexcept {
-        return trailer::extract_bit<trailer::reference_lock_bit>(raw());
+    /**
+     * Get associated context packet count.
+     * Returns count (0-127) if E bit is set, nullopt otherwise.
+     * Per Rule 5.1.6-13: When E=1, count is valid. When E=0, count is undefined.
+     */
+    std::optional<uint8_t> context_packet_count() const noexcept {
+        auto value = raw();
+        bool e_bit = trailer::extract_bit<trailer::e_bit>(value);
+        if (!e_bit) {
+            return std::nullopt;
+        }
+        return static_cast<uint8_t>(
+            trailer::extract_field<trailer::context_packet_count_shift,
+                                   trailer::context_packet_count_mask>(value));
     }
 
-    bool agc_mgc() const noexcept { return trailer::extract_bit<trailer::agc_mgc_bit>(raw()); }
+    // ========================================================================
+    // 8 Named Indicators (from Table 5.1.6-1)
+    // Each returns indicator value if enabled, nullopt otherwise
+    // ========================================================================
 
-    bool detected_signal() const noexcept {
-        return trailer::extract_bit<trailer::detected_signal_bit>(raw());
+    /**
+     * Calibrated Time Indicator (Enable bit 31, Indicator bit 19)
+     */
+    std::optional<bool> calibrated_time() const noexcept {
+        return get_indicator<trailer::calibrated_time_enable_bit,
+                             trailer::calibrated_time_indicator_bit>();
     }
 
-    bool spectral_inversion() const noexcept {
-        return trailer::extract_bit<trailer::spectral_inversion_bit>(raw());
+    /**
+     * Valid Data Indicator (Enable bit 30, Indicator bit 18)
+     */
+    std::optional<bool> valid_data() const noexcept {
+        return get_indicator<trailer::valid_data_enable_bit, trailer::valid_data_indicator_bit>();
     }
 
-    bool over_range() const noexcept {
-        return trailer::extract_bit<trailer::over_range_bit>(raw());
+    /**
+     * Reference Lock Indicator (Enable bit 29, Indicator bit 17)
+     */
+    std::optional<bool> reference_lock() const noexcept {
+        return get_indicator<trailer::reference_lock_enable_bit,
+                             trailer::reference_lock_indicator_bit>();
     }
 
-    bool sample_loss() const noexcept {
-        return trailer::extract_bit<trailer::sample_loss_bit>(raw());
+    /**
+     * AGC/MGC Indicator (Enable bit 28, Indicator bit 16)
+     */
+    std::optional<bool> agc_mgc() const noexcept {
+        return get_indicator<trailer::agc_mgc_enable_bit, trailer::agc_mgc_indicator_bit>();
     }
 
-    bool calibrated_time() const noexcept {
-        return trailer::extract_bit<trailer::calibrated_time_bit>(raw());
+    /**
+     * Detected Signal Indicator (Enable bit 27, Indicator bit 15)
+     */
+    std::optional<bool> detected_signal() const noexcept {
+        return get_indicator<trailer::detected_signal_enable_bit,
+                             trailer::detected_signal_indicator_bit>();
     }
 
-    bool valid_data() const noexcept {
-        return trailer::extract_bit<trailer::valid_data_bit>(raw());
+    /**
+     * Spectral Inversion Indicator (Enable bit 26, Indicator bit 14)
+     */
+    std::optional<bool> spectral_inversion() const noexcept {
+        return get_indicator<trailer::spectral_inversion_enable_bit,
+                             trailer::spectral_inversion_indicator_bit>();
     }
 
-    bool reference_point() const noexcept {
-        return trailer::extract_bit<trailer::reference_point_bit>(raw());
+    /**
+     * Over-range Indicator (Enable bit 25, Indicator bit 13)
+     */
+    std::optional<bool> over_range() const noexcept {
+        return get_indicator<trailer::over_range_enable_bit, trailer::over_range_indicator_bit>();
     }
 
-    bool signal_detected() const noexcept {
-        return trailer::extract_bit<trailer::signal_detected_bit>(raw());
+    /**
+     * Sample Loss Indicator (Enable bit 24, Indicator bit 12)
+     */
+    std::optional<bool> sample_loss() const noexcept {
+        return get_indicator<trailer::sample_loss_enable_bit, trailer::sample_loss_indicator_bit>();
     }
 
-    bool has_errors() const noexcept { return trailer::has_errors(raw()); }
+    // ========================================================================
+    // Sample Frame and User-Defined Indicators (bits 11-8)
+    // No enable bits - direct boolean access
+    // ========================================================================
+
+    /**
+     * Sample Frame 1 indicator (bit 11)
+     */
+    bool sample_frame_1() const noexcept {
+        return trailer::extract_bit<trailer::sample_frame_1_bit>(raw());
+    }
+
+    /**
+     * Sample Frame 0 indicator (bit 10)
+     */
+    bool sample_frame_0() const noexcept {
+        return trailer::extract_bit<trailer::sample_frame_0_bit>(raw());
+    }
+
+    /**
+     * User Defined 1 indicator (bit 9)
+     */
+    bool user_defined_1() const noexcept {
+        return trailer::extract_bit<trailer::user_defined_1_bit>(raw());
+    }
+
+    /**
+     * User Defined 0 indicator (bit 8)
+     */
+    bool user_defined_0() const noexcept {
+        return trailer::extract_bit<trailer::user_defined_0_bit>(raw());
+    }
 
 protected:
     const uint8_t* data_ptr() const noexcept { return word_ptr_; }
 
 private:
+    /**
+     * Helper to get an indicator value if its enable bit is set
+     */
+    template <uint32_t EnableBit, uint32_t IndicatorBit>
+    std::optional<bool> get_indicator() const noexcept {
+        auto value = raw();
+        bool enabled = trailer::extract_bit<EnableBit>(value);
+        if (!enabled) {
+            return std::nullopt;
+        }
+        return trailer::extract_bit<IndicatorBit>(value);
+    }
+
     const uint8_t* word_ptr_;
 };
 
 /**
  * Mutable view over a trailer word with typed setters.
+ *
+ * Setters automatically handle enable/indicator bit pairing:
+ * - set_X(value) sets enable bit to 1 and indicator bit to value
+ * - clear_X() sets enable bit to 0 (making indicator invalid)
  */
-class TrailerView : public ConstTrailerView {
+class MutableTrailerView : public TrailerView {
 public:
-    explicit TrailerView(uint8_t* word_ptr) noexcept
-        : ConstTrailerView(word_ptr),
+    explicit MutableTrailerView(uint8_t* word_ptr) noexcept
+        : TrailerView(word_ptr),
           word_ptr_mut_(word_ptr) {}
 
+    /**
+     * Set raw trailer word value (host byte order)
+     */
     void set_raw(uint32_t value) noexcept {
         value = detail::host_to_network32(value);
         std::memcpy(word_ptr_mut_, &value, sizeof(value));
     }
 
+    /**
+     * Clear entire trailer word to zero
+     */
     void clear() noexcept { set_raw(0); }
 
-    void set_context_packets(uint8_t count) noexcept {
+    // ========================================================================
+    // Associated Context Packet Count
+    // ========================================================================
+
+    /**
+     * Set associated context packet count.
+     * Sets E bit (bit 7) to 1 and count (bits 6-0) to specified value.
+     * Count is clamped to 0-127 range.
+     */
+    void set_context_packet_count(uint8_t count) noexcept {
         modify([count](uint32_t value) {
-            return trailer::set_field<trailer::context_packets_shift,
-                                      trailer::context_packets_mask>(value, count);
+            // Set E bit
+            value = trailer::set_bit<trailer::e_bit>(value, true);
+            // Set count field (bits 6-0)
+            return trailer::set_field<trailer::context_packet_count_shift,
+                                      trailer::context_packet_count_mask>(value, count);
         });
     }
 
-    void set_reference_lock(bool locked) noexcept {
-        modify([locked](uint32_t value) {
-            return trailer::set_bit<trailer::reference_lock_bit>(value, locked);
+    /**
+     * Clear context packet count (sets E bit to 0, making count invalid)
+     */
+    void clear_context_packet_count() noexcept {
+        modify([](uint32_t value) { return trailer::clear_bit<trailer::e_bit>(value); });
+    }
+
+    // ========================================================================
+    // 8 Named Indicators - Setters
+    // Each setter sets the enable bit AND the indicator bit
+    // ========================================================================
+
+    /**
+     * Set Calibrated Time indicator
+     * Sets enable bit 31 and indicator bit 19
+     */
+    void set_calibrated_time(bool value) noexcept {
+        set_indicator<trailer::calibrated_time_enable_bit, trailer::calibrated_time_indicator_bit>(
+            value);
+    }
+
+    /**
+     * Set Valid Data indicator
+     * Sets enable bit 30 and indicator bit 18
+     */
+    void set_valid_data(bool value) noexcept {
+        set_indicator<trailer::valid_data_enable_bit, trailer::valid_data_indicator_bit>(value);
+    }
+
+    /**
+     * Set Reference Lock indicator
+     * Sets enable bit 29 and indicator bit 17
+     */
+    void set_reference_lock(bool value) noexcept {
+        set_indicator<trailer::reference_lock_enable_bit, trailer::reference_lock_indicator_bit>(
+            value);
+    }
+
+    /**
+     * Set AGC/MGC indicator
+     * Sets enable bit 28 and indicator bit 16
+     */
+    void set_agc_mgc(bool value) noexcept {
+        set_indicator<trailer::agc_mgc_enable_bit, trailer::agc_mgc_indicator_bit>(value);
+    }
+
+    /**
+     * Set Detected Signal indicator
+     * Sets enable bit 27 and indicator bit 15
+     */
+    void set_detected_signal(bool value) noexcept {
+        set_indicator<trailer::detected_signal_enable_bit, trailer::detected_signal_indicator_bit>(
+            value);
+    }
+
+    /**
+     * Set Spectral Inversion indicator
+     * Sets enable bit 26 and indicator bit 14
+     */
+    void set_spectral_inversion(bool value) noexcept {
+        set_indicator<trailer::spectral_inversion_enable_bit,
+                      trailer::spectral_inversion_indicator_bit>(value);
+    }
+
+    /**
+     * Set Over-range indicator
+     * Sets enable bit 25 and indicator bit 13
+     */
+    void set_over_range(bool value) noexcept {
+        set_indicator<trailer::over_range_enable_bit, trailer::over_range_indicator_bit>(value);
+    }
+
+    /**
+     * Set Sample Loss indicator
+     * Sets enable bit 24 and indicator bit 12
+     */
+    void set_sample_loss(bool value) noexcept {
+        set_indicator<trailer::sample_loss_enable_bit, trailer::sample_loss_indicator_bit>(value);
+    }
+
+    // ========================================================================
+    // 8 Named Indicators - Clear methods
+    // Each clear method sets only the enable bit to 0
+    // ========================================================================
+
+    void clear_calibrated_time() noexcept { clear_enable<trailer::calibrated_time_enable_bit>(); }
+
+    void clear_valid_data() noexcept { clear_enable<trailer::valid_data_enable_bit>(); }
+
+    void clear_reference_lock() noexcept { clear_enable<trailer::reference_lock_enable_bit>(); }
+
+    void clear_agc_mgc() noexcept { clear_enable<trailer::agc_mgc_enable_bit>(); }
+
+    void clear_detected_signal() noexcept { clear_enable<trailer::detected_signal_enable_bit>(); }
+
+    void clear_spectral_inversion() noexcept {
+        clear_enable<trailer::spectral_inversion_enable_bit>();
+    }
+
+    void clear_over_range() noexcept { clear_enable<trailer::over_range_enable_bit>(); }
+
+    void clear_sample_loss() noexcept { clear_enable<trailer::sample_loss_enable_bit>(); }
+
+    // ========================================================================
+    // Sample Frame and User-Defined - Setters
+    // ========================================================================
+
+    void set_sample_frame_1(bool value) noexcept {
+        modify([value](uint32_t v) {
+            return trailer::set_bit<trailer::sample_frame_1_bit>(v, value);
         });
     }
 
-    void set_agc_mgc(bool active) noexcept {
-        modify([active](uint32_t value) {
-            return trailer::set_bit<trailer::agc_mgc_bit>(value, active);
+    void set_sample_frame_0(bool value) noexcept {
+        modify([value](uint32_t v) {
+            return trailer::set_bit<trailer::sample_frame_0_bit>(v, value);
         });
     }
 
-    void set_detected_signal(bool detected) noexcept {
-        modify([detected](uint32_t value) {
-            return trailer::set_bit<trailer::detected_signal_bit>(value, detected);
+    void set_user_defined_1(bool value) noexcept {
+        modify([value](uint32_t v) {
+            return trailer::set_bit<trailer::user_defined_1_bit>(v, value);
         });
     }
 
-    void set_spectral_inversion(bool inverted) noexcept {
-        modify([inverted](uint32_t value) {
-            return trailer::set_bit<trailer::spectral_inversion_bit>(value, inverted);
+    void set_user_defined_0(bool value) noexcept {
+        modify([value](uint32_t v) {
+            return trailer::set_bit<trailer::user_defined_0_bit>(v, value);
         });
     }
 
-    void set_over_range(bool over_range) noexcept {
-        modify([over_range](uint32_t value) {
-            return trailer::set_bit<trailer::over_range_bit>(value, over_range);
-        });
+    // ========================================================================
+    // Sample Frame and User-Defined - Clear methods
+    // ========================================================================
+
+    void clear_sample_frame_1() noexcept {
+        modify([](uint32_t v) { return trailer::clear_bit<trailer::sample_frame_1_bit>(v); });
     }
 
-    void set_sample_loss(bool loss) noexcept {
-        modify([loss](uint32_t value) {
-            return trailer::set_bit<trailer::sample_loss_bit>(value, loss);
-        });
+    void clear_sample_frame_0() noexcept {
+        modify([](uint32_t v) { return trailer::clear_bit<trailer::sample_frame_0_bit>(v); });
     }
 
-    void set_calibrated_time(bool calibrated) noexcept {
-        modify([calibrated](uint32_t value) {
-            return trailer::set_bit<trailer::calibrated_time_bit>(value, calibrated);
-        });
+    void clear_user_defined_1() noexcept {
+        modify([](uint32_t v) { return trailer::clear_bit<trailer::user_defined_1_bit>(v); });
     }
 
-    void set_valid_data(bool valid) noexcept {
-        modify([valid](uint32_t value) {
-            return trailer::set_bit<trailer::valid_data_bit>(value, valid);
-        });
-    }
-
-    void set_reference_point(bool ref_point) noexcept {
-        modify([ref_point](uint32_t value) {
-            return trailer::set_bit<trailer::reference_point_bit>(value, ref_point);
-        });
-    }
-
-    void set_signal_detected(bool detected) noexcept {
-        modify([detected](uint32_t value) {
-            return trailer::set_bit<trailer::signal_detected_bit>(value, detected);
-        });
+    void clear_user_defined_0() noexcept {
+        modify([](uint32_t v) { return trailer::clear_bit<trailer::user_defined_0_bit>(v); });
     }
 
 private:
+    /**
+     * Helper to set an indicator: sets enable bit to 1 and indicator bit to value
+     */
+    template <uint32_t EnableBit, uint32_t IndicatorBit>
+    void set_indicator(bool value) noexcept {
+        modify([value](uint32_t v) {
+            // Set enable bit to 1
+            v = trailer::set_bit<EnableBit>(v, true);
+            // Set indicator bit to value
+            return trailer::set_bit<IndicatorBit>(v, value);
+        });
+    }
+
+    /**
+     * Helper to clear an enable bit (makes corresponding indicator invalid)
+     */
+    template <uint32_t EnableBit>
+    void clear_enable() noexcept {
+        modify([](uint32_t v) { return trailer::clear_bit<EnableBit>(v); });
+    }
+
+    /**
+     * Read-modify-write helper
+     */
     template <typename Fn>
     void modify(Fn&& fn) noexcept {
         auto value = raw();
@@ -187,68 +419,106 @@ public:
         return *this;
     }
 
-    constexpr TrailerBuilder& context_packets(uint8_t count) noexcept {
-        value_ = trailer::set_field<trailer::context_packets_shift, trailer::context_packets_mask>(
-            value_, count);
+    // ========================================================================
+    // Context Packet Count
+    // ========================================================================
+
+    constexpr TrailerBuilder& context_packet_count(uint8_t count) noexcept {
+        // Set E bit
+        value_ = trailer::set_bit<trailer::e_bit>(value_, true);
+        // Set count
+        value_ = trailer::set_field<trailer::context_packet_count_shift,
+                                    trailer::context_packet_count_mask>(value_, count);
         return *this;
     }
 
-    constexpr TrailerBuilder& reference_lock(bool locked) noexcept {
-        value_ = trailer::set_bit<trailer::reference_lock_bit>(value_, locked);
+    // ========================================================================
+    // Named Indicators
+    // ========================================================================
+
+    constexpr TrailerBuilder& calibrated_time(bool indicator_value) noexcept {
+        value_ = trailer::set_bit<trailer::calibrated_time_enable_bit>(value_, true);
+        value_ = trailer::set_bit<trailer::calibrated_time_indicator_bit>(value_, indicator_value);
         return *this;
     }
 
-    constexpr TrailerBuilder& agc_mgc(bool active) noexcept {
-        value_ = trailer::set_bit<trailer::agc_mgc_bit>(value_, active);
+    constexpr TrailerBuilder& valid_data(bool indicator_value) noexcept {
+        value_ = trailer::set_bit<trailer::valid_data_enable_bit>(value_, true);
+        value_ = trailer::set_bit<trailer::valid_data_indicator_bit>(value_, indicator_value);
         return *this;
     }
 
-    constexpr TrailerBuilder& detected_signal(bool detected) noexcept {
-        value_ = trailer::set_bit<trailer::detected_signal_bit>(value_, detected);
+    constexpr TrailerBuilder& reference_lock(bool indicator_value) noexcept {
+        value_ = trailer::set_bit<trailer::reference_lock_enable_bit>(value_, true);
+        value_ = trailer::set_bit<trailer::reference_lock_indicator_bit>(value_, indicator_value);
         return *this;
     }
 
-    constexpr TrailerBuilder& spectral_inversion(bool inverted) noexcept {
-        value_ = trailer::set_bit<trailer::spectral_inversion_bit>(value_, inverted);
+    constexpr TrailerBuilder& agc_mgc(bool indicator_value) noexcept {
+        value_ = trailer::set_bit<trailer::agc_mgc_enable_bit>(value_, true);
+        value_ = trailer::set_bit<trailer::agc_mgc_indicator_bit>(value_, indicator_value);
         return *this;
     }
 
-    constexpr TrailerBuilder& over_range(bool over_range) noexcept {
-        value_ = trailer::set_bit<trailer::over_range_bit>(value_, over_range);
+    constexpr TrailerBuilder& detected_signal(bool indicator_value) noexcept {
+        value_ = trailer::set_bit<trailer::detected_signal_enable_bit>(value_, true);
+        value_ = trailer::set_bit<trailer::detected_signal_indicator_bit>(value_, indicator_value);
         return *this;
     }
 
-    constexpr TrailerBuilder& sample_loss(bool loss) noexcept {
-        value_ = trailer::set_bit<trailer::sample_loss_bit>(value_, loss);
+    constexpr TrailerBuilder& spectral_inversion(bool indicator_value) noexcept {
+        value_ = trailer::set_bit<trailer::spectral_inversion_enable_bit>(value_, true);
+        value_ =
+            trailer::set_bit<trailer::spectral_inversion_indicator_bit>(value_, indicator_value);
         return *this;
     }
 
-    constexpr TrailerBuilder& calibrated_time(bool calibrated) noexcept {
-        value_ = trailer::set_bit<trailer::calibrated_time_bit>(value_, calibrated);
+    constexpr TrailerBuilder& over_range(bool indicator_value) noexcept {
+        value_ = trailer::set_bit<trailer::over_range_enable_bit>(value_, true);
+        value_ = trailer::set_bit<trailer::over_range_indicator_bit>(value_, indicator_value);
         return *this;
     }
 
-    constexpr TrailerBuilder& valid_data(bool valid) noexcept {
-        value_ = trailer::set_bit<trailer::valid_data_bit>(value_, valid);
+    constexpr TrailerBuilder& sample_loss(bool indicator_value) noexcept {
+        value_ = trailer::set_bit<trailer::sample_loss_enable_bit>(value_, true);
+        value_ = trailer::set_bit<trailer::sample_loss_indicator_bit>(value_, indicator_value);
         return *this;
     }
 
-    constexpr TrailerBuilder& reference_point(bool ref_point) noexcept {
-        value_ = trailer::set_bit<trailer::reference_point_bit>(value_, ref_point);
+    // ========================================================================
+    // Sample Frame and User-Defined
+    // ========================================================================
+
+    constexpr TrailerBuilder& sample_frame_1(bool value) noexcept {
+        value_ = trailer::set_bit<trailer::sample_frame_1_bit>(value_, value);
         return *this;
     }
 
-    constexpr TrailerBuilder& signal_detected(bool detected) noexcept {
-        value_ = trailer::set_bit<trailer::signal_detected_bit>(value_, detected);
+    constexpr TrailerBuilder& sample_frame_0(bool value) noexcept {
+        value_ = trailer::set_bit<trailer::sample_frame_0_bit>(value_, value);
         return *this;
     }
 
-    TrailerBuilder& from_view(ConstTrailerView view) noexcept {
+    constexpr TrailerBuilder& user_defined_1(bool value) noexcept {
+        value_ = trailer::set_bit<trailer::user_defined_1_bit>(value_, value);
+        return *this;
+    }
+
+    constexpr TrailerBuilder& user_defined_0(bool value) noexcept {
+        value_ = trailer::set_bit<trailer::user_defined_0_bit>(value_, value);
+        return *this;
+    }
+
+    // ========================================================================
+    // Utility Methods
+    // ========================================================================
+
+    TrailerBuilder& from_view(TrailerView view) noexcept {
         value_ = view.raw();
         return *this;
     }
 
-    TrailerView apply(TrailerView view) const noexcept {
+    MutableTrailerView apply(MutableTrailerView view) const noexcept {
         view.set_raw(value_);
         return view;
     }

--- a/include/vrtio/utils/detail/iteration_helpers.hpp
+++ b/include/vrtio/utils/detail/iteration_helpers.hpp
@@ -8,7 +8,7 @@
 
 #include "../../detail/context_packet_view.hpp"
 #include "../../detail/data_packet_view.hpp"
-#include "../fileio/packet_variant.hpp"
+#include "../../detail/packet_variant.hpp"
 
 namespace vrtio::utils::detail {
 
@@ -20,7 +20,7 @@ namespace vrtio::utils::detail {
  */
 template <typename T>
 concept PacketReader = requires(T& reader) {
-    { reader.read_next_packet() } -> std::same_as<std::optional<fileio::PacketVariant>>;
+    { reader.read_next_packet() } -> std::same_as<std::optional<vrtio::PacketVariant>>;
 };
 
 /**
@@ -130,7 +130,7 @@ size_t for_each_packet_with_stream_id(Reader& reader, uint32_t stream_id_filter,
     size_t count = 0;
 
     while (auto pkt = reader.read_next_packet()) {
-        auto sid = fileio::stream_id(*pkt);
+        auto sid = vrtio::stream_id(*pkt);
         if (sid && *sid == stream_id_filter) {
             bool continue_processing = callback(*pkt);
             count++;

--- a/include/vrtio/utils/detail/writer_concepts.hpp
+++ b/include/vrtio/utils/detail/writer_concepts.hpp
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include "vrtio/utils/fileio/packet_variant.hpp"
+#include "vrtio/detail/packet_variant.hpp"
 
 #include <concepts>
 
@@ -20,7 +20,7 @@ namespace vrtio::utils::detail {
  * @tparam T The type to check
  */
 template <typename T>
-concept PacketWriter = requires(T& writer, const fileio::PacketVariant& pv) {
+concept PacketWriter = requires(T& writer, const vrtio::PacketVariant& pv) {
     { writer.write_packet(pv) } -> std::same_as<bool>;
     { writer.packets_written() } -> std::same_as<size_t>;
 };

--- a/include/vrtio/utils/fileio/vrt_file_reader.hpp
+++ b/include/vrtio/utils/fileio/vrt_file_reader.hpp
@@ -5,9 +5,9 @@
 #include <string>
 #include <utility>
 
+#include "../../detail/packet_parser.hpp"
+#include "../../detail/packet_variant.hpp"
 #include "../detail/iteration_helpers.hpp"
-#include "detail/packet_parser.hpp"
-#include "packet_variant.hpp"
 #include "raw_vrt_file_reader.hpp"
 
 namespace vrtio::utils::fileio {
@@ -111,7 +111,7 @@ public:
      * @note The returned view references the internal reader buffer and is valid
      *       until the next read operation.
      */
-    std::optional<PacketVariant> read_next_packet() noexcept {
+    std::optional<vrtio::PacketVariant> read_next_packet() noexcept {
         auto bytes = reader_.read_next_span();
 
         // Check for EOF
@@ -123,14 +123,14 @@ public:
         if (bytes.empty()) {
             const auto& err = reader_.last_error();
             auto decoded = vrtio::detail::decode_header(err.header);
-            return PacketVariant{InvalidPacket{
+            return vrtio::PacketVariant{vrtio::InvalidPacket{
                 err.error, err.type, decoded,
                 std::span<const uint8_t>() // Empty span since read failed
             }};
         }
 
         // Parse and validate the packet
-        return detail_packet_parsing::parse_and_validate_packet(bytes);
+        return vrtio::detail::parse_packet(bytes);
     }
 
     /**

--- a/include/vrtio/utils/fileio/vrt_file_writer.hpp
+++ b/include/vrtio/utils/fileio/vrt_file_writer.hpp
@@ -4,8 +4,8 @@
 #pragma once
 
 #include "vrtio/detail/packet_concepts.hpp"
+#include "vrtio/detail/packet_variant.hpp"
 #include "vrtio/utils/detail/writer_concepts.hpp"
-#include "vrtio/utils/fileio/packet_variant.hpp"
 #include "vrtio/utils/fileio/raw_vrt_file_writer.hpp"
 #include "vrtio/utils/fileio/writer_status.hpp"
 

--- a/include/vrtio/utils/netio/udp_vrt_writer.hpp
+++ b/include/vrtio/utils/netio/udp_vrt_writer.hpp
@@ -17,8 +17,8 @@
 
 // Linux/POSIX socket headers
 #include "vrtio/detail/packet_concepts.hpp"
+#include "vrtio/detail/packet_variant.hpp"
 #include "vrtio/utils/detail/writer_concepts.hpp"
-#include "vrtio/utils/fileio/packet_variant.hpp"
 #include "vrtio/utils/netio/udp_transport_status.hpp"
 
 #include <arpa/inet.h>
@@ -94,7 +94,7 @@ namespace vrtio::utils::netio {
  * // Convert to variant for per-destination API
  * auto bytes = packet.as_bytes();
  * vrtio::DataPacketView packet_view{bytes.data(), bytes.size()};
- * vrtio::utils::fileio::PacketVariant variant = packet_view;
+ * vrtio::PacketVariant variant = packet_view;
  *
  * multi_writer.write_packet(variant, dest1);
  * multi_writer.write_packet(variant, dest2);
@@ -237,9 +237,9 @@ public:
      * @param packet The packet variant to write
      * @return true on success, false on error or invalid packet
      */
-    bool write_packet(const fileio::PacketVariant& packet) noexcept {
+    bool write_packet(const vrtio::PacketVariant& packet) noexcept {
         // Check if variant holds InvalidPacket
-        if (std::holds_alternative<fileio::InvalidPacket>(packet)) {
+        if (std::holds_alternative<vrtio::InvalidPacket>(packet)) {
             status_.state = UDPTransportStatus::State::socket_error;
             status_.errno_value = EINVAL;
             return false;
@@ -251,7 +251,7 @@ public:
                 using T = std::decay_t<decltype(pkt)>;
 
                 // InvalidPacket already handled above
-                if constexpr (std::is_same_v<T, fileio::InvalidPacket>) {
+                if constexpr (std::is_same_v<T, vrtio::InvalidPacket>) {
                     return false; // Should never reach here
                 } else if constexpr (std::is_same_v<T, vrtio::DataPacketView>) {
                     return this->write_packet_impl(pkt.as_bytes());
@@ -312,10 +312,9 @@ public:
      * @param dest Destination address
      * @return true on success, false on error or invalid packet
      */
-    bool write_packet(const fileio::PacketVariant& packet,
-                      const struct sockaddr_in& dest) noexcept {
+    bool write_packet(const vrtio::PacketVariant& packet, const struct sockaddr_in& dest) noexcept {
         // Check if variant holds InvalidPacket
-        if (std::holds_alternative<fileio::InvalidPacket>(packet)) {
+        if (std::holds_alternative<vrtio::InvalidPacket>(packet)) {
             status_.state = UDPTransportStatus::State::socket_error;
             status_.errno_value = EINVAL;
             return false;
@@ -326,7 +325,7 @@ public:
             [this, &dest](auto&& pkt) -> bool {
                 using T = std::decay_t<decltype(pkt)>;
 
-                if constexpr (std::is_same_v<T, fileio::InvalidPacket>) {
+                if constexpr (std::is_same_v<T, vrtio::InvalidPacket>) {
                     return false; // Should never reach here
                 } else if constexpr (std::is_same_v<T, vrtio::DataPacketView>) {
                     return this->write_packet_to(pkt.as_bytes(), dest);

--- a/tests/builder_test.cpp
+++ b/tests/builder_test.cpp
@@ -44,7 +44,7 @@ TEST_F(BuilderTest, FluentChaining) {
     alignas(4) std::array<uint8_t, PacketType::size_bytes> buffer{};
 
     // Single expression with all fields
-    auto trailer_cfg = vrtio::TrailerBuilder{}.clear().context_packets(1);
+    auto trailer_cfg = vrtio::TrailerBuilder{}.clear().context_packet_count(1);
 
     auto ts = vrtio::TimeStampUTC::from_components(1234567890, 500000000000ULL);
     auto packet = vrtio::PacketBuilder<PacketType>(buffer.data())
@@ -58,7 +58,8 @@ TEST_F(BuilderTest, FluentChaining) {
     EXPECT_EQ(packet.stream_id(), 0xABCDEF00);
     EXPECT_EQ(read_ts.seconds(), 1234567890);
     EXPECT_EQ(read_ts.fractional(), 500000000000ULL);
-    EXPECT_EQ(packet.trailer().raw(), 0x00000001);
+    // context_packet_count(1) sets count=1 (bit 0) and E bit=1 (bit 7) = 0x81
+    EXPECT_EQ(packet.trailer().raw(), 0x00000081);
     EXPECT_EQ(packet.packet_count(), 10);
 }
 
@@ -71,7 +72,7 @@ TEST_F(BuilderTest, TrailerBuilderValueObject) {
     auto trailer_cfg = vrtio::TrailerBuilder{}
                            .valid_data(true)
                            .calibrated_time(true)
-                           .context_packets(7)
+                           .context_packet_count(7)
                            .reference_lock(true);
 
     auto packet = vrtio::PacketBuilder<PacketType>(buffer.data())
@@ -82,7 +83,7 @@ TEST_F(BuilderTest, TrailerBuilderValueObject) {
 
     EXPECT_TRUE(packet.trailer().valid_data());
     EXPECT_TRUE(packet.trailer().calibrated_time());
-    EXPECT_EQ(packet.trailer().context_packets(), 7);
+    EXPECT_EQ(packet.trailer().context_packet_count(), 7);
     EXPECT_TRUE(packet.trailer().reference_lock());
 }
 
@@ -96,7 +97,7 @@ TEST_F(BuilderTest, TrailerBuilderChaining) {
                            .clear()
                            .valid_data(true)
                            .calibrated_time(true)
-                           .context_packets(3)
+                           .context_packet_count(3)
                            .over_range(true);
 
     auto packet = vrtio::PacketBuilder<PacketType>(buffer.data())
@@ -107,7 +108,7 @@ TEST_F(BuilderTest, TrailerBuilderChaining) {
 
     EXPECT_TRUE(packet.trailer().valid_data());
     EXPECT_TRUE(packet.trailer().calibrated_time());
-    EXPECT_EQ(packet.trailer().context_packets(), 3);
+    EXPECT_EQ(packet.trailer().context_packet_count(), 3);
     EXPECT_TRUE(packet.trailer().over_range());
     EXPECT_EQ(packet.packet_count(), 4);
 }

--- a/tests/cif/cif1_test.cpp
+++ b/tests/cif/cif1_test.cpp
@@ -21,20 +21,20 @@ TEST_F(ContextPacketTest, NewCIF1Fields) {
     TestContext packet(buffer.data());
 
     // Set and verify Health Status (1 word)
-    packet[health_status].set_raw_value(0xABCDEF01);
-    EXPECT_EQ(packet[health_status].raw_value(), 0xABCDEF01);
+    packet[health_status].set_encoded(0xABCDEF01);
+    EXPECT_EQ(packet[health_status].encoded(), 0xABCDEF01);
 
     // Set and verify Phase Offset (1 word)
-    packet[phase_offset].set_raw_value(0x12345678);
-    EXPECT_EQ(packet[phase_offset].raw_value(), 0x12345678);
+    packet[phase_offset].set_encoded(0x12345678);
+    EXPECT_EQ(packet[phase_offset].encoded(), 0x12345678);
 
     // Set and verify Polarization (1 word)
-    packet[polarization].set_raw_value(0x87654321);
-    EXPECT_EQ(packet[polarization].raw_value(), 0x87654321);
+    packet[polarization].set_encoded(0x87654321);
+    EXPECT_EQ(packet[polarization].encoded(), 0x87654321);
 
     // Set and verify 3D Pointing Single (1 word)
-    packet[pointing_vector_3d_single].set_raw_value(0xFEDCBA98);
-    EXPECT_EQ(packet[pointing_vector_3d_single].raw_value(), 0xFEDCBA98);
+    packet[pointing_vector_3d_single].set_encoded(0xFEDCBA98);
+    EXPECT_EQ(packet[pointing_vector_3d_single].encoded(), 0xFEDCBA98);
 }
 
 TEST_F(ContextPacketTest, RuntimeParseCIF1) {
@@ -70,7 +70,7 @@ TEST_F(ContextPacketTest, RuntimeParseCIF1) {
     // Verify we can read back the Aux Frequency field using the accessor
     auto aux_freq = view[aux_frequency];
     ASSERT_TRUE(aux_freq.has_value());
-    EXPECT_EQ(aux_freq.raw_value(), expected_freq);
+    EXPECT_EQ(aux_freq.encoded(), expected_freq);
 }
 
 TEST_F(ContextPacketTest, CompileTimeCIF1RuntimeParse) {
@@ -85,7 +85,7 @@ TEST_F(ContextPacketTest, CompileTimeCIF1RuntimeParse) {
 
     TestContext tx_packet(buffer.data());
     tx_packet.set_stream_id(0xAABBCCDD);
-    tx_packet[aux_frequency].set_raw_value(15'000'000ULL); // 15 MHz
+    tx_packet[aux_frequency].set_encoded(15'000'000ULL); // 15 MHz
 
     // Parse with runtime view
     ContextPacketView view(buffer.data(), TestContext::size_bytes);

--- a/tests/cif/cif2_test.cpp
+++ b/tests/cif/cif2_test.cpp
@@ -52,7 +52,7 @@ TEST_F(ContextPacketTest, RuntimeParseCIF2) {
     // Verify we can read back the Controller UUID field using operator[] API
     auto uuid_proxy = view[field::controller_uuid];
     ASSERT_TRUE(uuid_proxy.has_value());
-    auto uuid = uuid_proxy.raw_bytes();
+    auto uuid = uuid_proxy.bytes();
     ASSERT_EQ(uuid.size(), 16); // 128 bits = 16 bytes
 
     // Verify UUID bytes match what we wrote

--- a/tests/cif/cif3_test.cpp
+++ b/tests/cif/cif3_test.cpp
@@ -9,18 +9,18 @@ TEST_F(ContextPacketTest, CIF3FieldsBasic) {
     TestContext packet(buffer.data());
 
     // Test 1-word fields
-    packet[field::network_id].set_raw_value(0x11111111);
-    EXPECT_EQ(packet[field::network_id].raw_value(), 0x11111111);
+    packet[field::network_id].set_encoded(0x11111111);
+    EXPECT_EQ(packet[field::network_id].encoded(), 0x11111111);
 
-    packet[field::tropospheric_state].set_raw_value(0x22222222);
-    EXPECT_EQ(packet[field::tropospheric_state].raw_value(), 0x22222222);
+    packet[field::tropospheric_state].set_encoded(0x22222222);
+    EXPECT_EQ(packet[field::tropospheric_state].encoded(), 0x22222222);
 
     // Test 2-word (64-bit) fields
-    packet[field::jitter].set_raw_value(0x3333333344444444ULL);
-    EXPECT_EQ(packet[field::jitter].raw_value(), 0x3333333344444444ULL);
+    packet[field::jitter].set_encoded(0x3333333344444444ULL);
+    EXPECT_EQ(packet[field::jitter].encoded(), 0x3333333344444444ULL);
 
-    packet[field::pulse_width].set_raw_value(0x5555555566666666ULL);
-    EXPECT_EQ(packet[field::pulse_width].raw_value(), 0x5555555566666666ULL);
+    packet[field::pulse_width].set_encoded(0x5555555566666666ULL);
+    EXPECT_EQ(packet[field::pulse_width].encoded(), 0x5555555566666666ULL);
 }
 
 TEST_F(ContextPacketTest, RuntimeParseCIF3) {
@@ -54,7 +54,7 @@ TEST_F(ContextPacketTest, RuntimeParseCIF3) {
 
     // Verify field value
     EXPECT_TRUE(view[field::network_id]);
-    EXPECT_EQ(view[field::network_id].raw_value(), 0xDEADBEEF);
+    EXPECT_EQ(view[field::network_id].encoded(), 0xDEADBEEF);
 }
 
 TEST_F(ContextPacketTest, CompileTimeCIF3) {
@@ -64,8 +64,8 @@ TEST_F(ContextPacketTest, CompileTimeCIF3) {
     TestContext packet(buffer.data());
 
     // Set field values
-    packet[network_id].set_raw_value(0x11111111);
-    packet[tropospheric_state].set_raw_value(0x22222222);
+    packet[network_id].set_encoded(0x11111111);
+    packet[tropospheric_state].set_encoded(0x22222222);
 
     // Verify CIF3 word is written correctly
     constexpr uint32_t expected_cif3 = vrtio::detail::field_bitmask<network_id>() |
@@ -73,13 +73,13 @@ TEST_F(ContextPacketTest, CompileTimeCIF3) {
     EXPECT_EQ(packet.cif3(), expected_cif3);
 
     // Verify field values are correct (not overwriting CIF3 word)
-    EXPECT_EQ(packet[network_id].raw_value(), 0x11111111);
-    EXPECT_EQ(packet[tropospheric_state].raw_value(), 0x22222222);
+    EXPECT_EQ(packet[network_id].encoded(), 0x11111111);
+    EXPECT_EQ(packet[tropospheric_state].encoded(), 0x22222222);
 
     // Parse as runtime packet to verify structure
     ContextPacketView view(buffer.data(), TestContext::size_bytes);
     EXPECT_EQ(view.error(), ValidationError::none);
     EXPECT_EQ(view.cif3(), expected_cif3);
-    EXPECT_EQ(view[network_id].raw_value(), 0x11111111);
-    EXPECT_EQ(view[tropospheric_state].raw_value(), 0x22222222);
+    EXPECT_EQ(view[network_id].encoded(), 0x11111111);
+    EXPECT_EQ(view[tropospheric_state].encoded(), 0x22222222);
 }

--- a/tests/cif/value_test.cpp
+++ b/tests/cif/value_test.cpp
@@ -29,7 +29,7 @@ TEST_F(InterpretedValueTest, BandwidthInterpretedRead) {
     // Set bandwidth to Q52.12 encoding for 100 MHz
     // 100 MHz = 100'000'000 Hz
     // Q52.12: 100'000'000 * 4096 = 409'600'000'000
-    packet[bandwidth].set_raw_value(409'600'000'000ULL);
+    packet[bandwidth].set_encoded(409'600'000'000ULL);
 
     // Read interpreted value
     double hz = packet[bandwidth].value();
@@ -48,7 +48,7 @@ TEST_F(InterpretedValueTest, BandwidthInterpretedWrite) {
 
     // Verify raw value is correct Q52.12 encoding
     // 50 MHz * 4096 = 204'800'000'000
-    EXPECT_EQ(packet[bandwidth].raw_value(), 204'800'000'000ULL);
+    EXPECT_EQ(packet[bandwidth].encoded(), 204'800'000'000ULL);
 }
 
 TEST_F(InterpretedValueTest, BandwidthRoundTrip) {
@@ -115,13 +115,13 @@ TEST_F(InterpretedValueTest, BandwidthEdgeCases) {
 
     // Zero value
     packet[bandwidth].set_value(0.0);
-    EXPECT_EQ(packet[bandwidth].raw_value(), 0ULL);
+    EXPECT_EQ(packet[bandwidth].encoded(), 0ULL);
     EXPECT_DOUBLE_EQ(packet[bandwidth].value(), 0.0);
 
     // Maximum Q52.12 value
     uint64_t max_q52_12 = 0xFFFFFFFFFFFFFFFFULL;
-    packet[bandwidth].set_raw_value(max_q52_12);
-    EXPECT_EQ(packet[bandwidth].raw_value(), max_q52_12);
+    packet[bandwidth].set_encoded(max_q52_12);
+    EXPECT_EQ(packet[bandwidth].encoded(), max_q52_12);
     double expected_hz = static_cast<double>(max_q52_12) / 4096.0;
     EXPECT_NEAR(packet[bandwidth].value(), expected_hz, 1.0);
 }
@@ -138,7 +138,7 @@ TEST_F(InterpretedValueTest, SampleRateInterpretedRead) {
     // Set sample rate to Q52.12 encoding for 50 MHz (50 MSPS)
     // 50 MHz = 50'000'000 Hz
     // Q52.12: 50'000'000 * 4096 = 204'800'000'000
-    packet[sample_rate].set_raw_value(204'800'000'000ULL);
+    packet[sample_rate].set_encoded(204'800'000'000ULL);
 
     // Read interpreted value
     double hz = packet[sample_rate].value();
@@ -157,7 +157,7 @@ TEST_F(InterpretedValueTest, SampleRateInterpretedWrite) {
 
     // Verify raw value is correct Q52.12 encoding
     // 25 MHz * 4096 = 102'400'000'000
-    EXPECT_EQ(packet[sample_rate].raw_value(), 102'400'000'000ULL);
+    EXPECT_EQ(packet[sample_rate].encoded(), 102'400'000'000ULL);
 }
 
 TEST_F(InterpretedValueTest, SampleRateRoundTrip) {
@@ -250,13 +250,13 @@ TEST_F(InterpretedValueTest, SampleRateEdgeCases) {
 
     // Zero value (stopped ADC)
     packet[sample_rate].set_value(0.0);
-    EXPECT_EQ(packet[sample_rate].raw_value(), 0ULL);
+    EXPECT_EQ(packet[sample_rate].encoded(), 0ULL);
     EXPECT_DOUBLE_EQ(packet[sample_rate].value(), 0.0);
 
     // Maximum Q52.12 value
     uint64_t max_q52_12 = 0xFFFFFFFFFFFFFFFFULL;
-    packet[sample_rate].set_raw_value(max_q52_12);
-    EXPECT_EQ(packet[sample_rate].raw_value(), max_q52_12);
+    packet[sample_rate].set_encoded(max_q52_12);
+    EXPECT_EQ(packet[sample_rate].encoded(), max_q52_12);
     double expected_hz = static_cast<double>(max_q52_12) / 4096.0;
     EXPECT_NEAR(packet[sample_rate].value(), expected_hz, 1.0);
 

--- a/tests/context_integration_test.cpp
+++ b/tests/context_integration_test.cpp
@@ -10,7 +10,7 @@ TEST_F(ContextPacketTest, RoundTrip) {
     TestContext tx_packet(buffer.data());
     tx_packet.set_stream_id(0xDEADBEEF);
     tx_packet[bandwidth].set_value(100'000'000.0); // 100 MHz
-    tx_packet[gain].set_raw_value(0x12345678U);
+    tx_packet[gain].set_encoded(0x12345678U);
 
     // Parse same buffer with view
     ContextPacketView view(buffer.data(), TestContext::size_bytes);
@@ -18,7 +18,7 @@ TEST_F(ContextPacketTest, RoundTrip) {
 
     EXPECT_EQ(view.stream_id().value(), 0xDEADBEEF);
     EXPECT_DOUBLE_EQ(view[bandwidth].value(), 100'000'000.0);
-    EXPECT_EQ(view[gain].raw_value(), 0x12345678);
+    EXPECT_EQ(view[gain].encoded(), 0x12345678);
 }
 
 TEST_F(ContextPacketTest, CombinedCIF1AndCIF2CompileTime) {
@@ -36,8 +36,8 @@ TEST_F(ContextPacketTest, CombinedCIF1AndCIF2CompileTime) {
 
     TestContext tx_packet(buffer.data());
     tx_packet.set_stream_id(0x11223344);
-    tx_packet[bandwidth].set_value(50'000'000.0);          // 50 MHz (has interpreted support)
-    tx_packet[aux_frequency].set_raw_value(25'000'000ULL); // Raw (no interpreted support)
+    tx_packet[bandwidth].set_value(50'000'000.0);        // 50 MHz (has interpreted support)
+    tx_packet[aux_frequency].set_encoded(25'000'000ULL); // Raw (no interpreted support)
 
     // Parse with runtime view
     ContextPacketView view(buffer.data(), TestContext::size_bytes);
@@ -53,7 +53,7 @@ TEST_F(ContextPacketTest, CombinedCIF1AndCIF2CompileTime) {
     // Verify fields
     EXPECT_EQ(view.stream_id().value(), 0x11223344);
     EXPECT_DOUBLE_EQ(view[bandwidth].value(), 50'000'000.0);
-    EXPECT_EQ(view[aux_frequency].raw_value(), 25'000'000);
+    EXPECT_EQ(view[aux_frequency].encoded(), 25'000'000);
 }
 
 TEST_F(ContextPacketTest, CombinedCIF1AndCIF2Runtime) {
@@ -102,12 +102,12 @@ TEST_F(ContextPacketTest, CombinedCIF1AndCIF2Runtime) {
 
     // Verify fields
     EXPECT_EQ(view.stream_id().value(), 0xAABBCCDD);
-    EXPECT_EQ(view[bandwidth].raw_value(), 100'000'000);
-    EXPECT_EQ(view[aux_frequency].raw_value(), 75'000'000);
+    EXPECT_EQ(view[bandwidth].encoded(), 100'000'000);
+    EXPECT_EQ(view[aux_frequency].encoded(), 75'000'000);
 
     auto uuid_proxy = view[controller_uuid];
     ASSERT_TRUE(uuid_proxy.has_value());
-    auto uuid = uuid_proxy.raw_bytes();
+    auto uuid = uuid_proxy.bytes();
     EXPECT_EQ(cif::read_u32_safe(uuid.data(), 0), 0x12345678);
 }
 
@@ -126,13 +126,13 @@ TEST_F(ContextPacketTest, MultiWordFieldWrite) {
     FieldView<2> field_value(source_data, 0);
 
     // Write the field to the packet
-    packet[data_payload_format].set_raw_value(field_value);
+    packet[data_payload_format].set_encoded(field_value);
 
     // Read it back and verify
     auto read_value = packet[data_payload_format];
     ASSERT_TRUE(read_value.has_value());
-    EXPECT_EQ(read_value.raw_value().word(0), 0xAABBCCDD);
-    EXPECT_EQ(read_value.raw_value().word(1), 0x11223344);
+    EXPECT_EQ(read_value.encoded().word(0), 0xAABBCCDD);
+    EXPECT_EQ(read_value.encoded().word(1), 0x11223344);
 
     // Verify round-trip through runtime parser
     ContextPacketView view(buffer.data(), TestContext::size_bytes);
@@ -140,6 +140,6 @@ TEST_F(ContextPacketTest, MultiWordFieldWrite) {
 
     auto runtime_value = view[data_payload_format];
     ASSERT_TRUE(runtime_value.has_value());
-    EXPECT_EQ(runtime_value.raw_value().word(0), 0xAABBCCDD);
-    EXPECT_EQ(runtime_value.raw_value().word(1), 0x11223344);
+    EXPECT_EQ(runtime_value.encoded().word(0), 0xAABBCCDD);
+    EXPECT_EQ(runtime_value.encoded().word(1), 0x11223344);
 }

--- a/tests/context_variable_test.cpp
+++ b/tests/context_variable_test.cpp
@@ -30,7 +30,7 @@ TEST_F(ContextPacketTest, GPSASCIIVariableField) {
     // Use operator[] API instead of has_gps_ascii() / gps_ascii_data()
     auto gps_proxy = view[gps_ascii];
     EXPECT_TRUE(gps_proxy.has_value());
-    auto gps_data = gps_proxy.raw_bytes();
+    auto gps_data = gps_proxy.bytes();
     EXPECT_EQ(gps_data.size(), 4 * 4); // 1 count + 3 data words (12 bytes)
 
     // Extract the character count
@@ -75,7 +75,7 @@ TEST_F(ContextPacketTest, ContextAssociationLists) {
     // Use operator[] API instead of has_context_association() / context_association_data()
     auto assoc_proxy = view[context_association_lists];
     EXPECT_TRUE(assoc_proxy.has_value());
-    auto assoc_data = assoc_proxy.raw_bytes();
+    auto assoc_data = assoc_proxy.bytes();
     EXPECT_EQ(assoc_data.size(), 4 * 4); // 1 counts + 2 stream + 1 context
 }
 

--- a/tests/field_access_test.cpp
+++ b/tests/field_access_test.cpp
@@ -28,7 +28,7 @@ int main() {
 
     packet[bandwidth].set_value(1'000'000.0);   // 1 MHz
     packet[sample_rate].set_value(2'000'000.0); // 2 MSPS
-    packet[gain].set_raw_value(42U);            // Gain has no interpreted support
+    packet[gain].set_encoded(42U);              // Gain has no interpreted support
 
     // =======================================================================
     // Test operator[] function
@@ -44,7 +44,7 @@ int main() {
 
     [[maybe_unused]] auto g = packet[gain];
     assert(g.has_value() && "Gain should be present");
-    assert(g.raw_value() == 42U && "Gain value should match");
+    assert(g.encoded() == 42U && "Gain value should match");
 
     // =======================================================================
     // Test operator[] for presence checking

--- a/tests/io/enhanced_reader_test.cpp
+++ b/tests/io/enhanced_reader_test.cpp
@@ -142,7 +142,7 @@ TEST(EnhancedReaderTest, ForEachValidatedPacket) {
 
     size_t callback_count = 0;
 
-    size_t processed = reader.for_each_validated_packet([&](const fileio::PacketVariant& pkt) {
+    size_t processed = reader.for_each_validated_packet([&](const vrtio::PacketVariant& pkt) {
         (void)pkt; // Only counting packets in this test
         callback_count++;
         return true; // Continue
@@ -188,7 +188,7 @@ TEST(EnhancedReaderTest, EarlyTermination) {
     size_t max_packets = 5;
     size_t count = 0;
 
-    reader.for_each_validated_packet([&](const fileio::PacketVariant&) {
+    reader.for_each_validated_packet([&](const vrtio::PacketVariant&) {
         count++;
         return count < max_packets; // Stop after 5 packets
     });
@@ -218,7 +218,7 @@ TEST(EnhancedReaderTest, FilterByStreamId) {
     reader.rewind();
 
     size_t matching_count = 0;
-    reader.for_each_packet_with_stream_id(*target_stream_id, [&](const fileio::PacketVariant& pkt) {
+    reader.for_each_packet_with_stream_id(*target_stream_id, [&](const vrtio::PacketVariant& pkt) {
         matching_count++;
         auto sid = stream_id(pkt);
         if (sid.has_value()) {
@@ -284,8 +284,8 @@ TEST(EnhancedReaderTest, InvalidPacketHasErrorInfo) {
     // This test just verifies the InvalidPacket structure works
 
     vrtio::detail::DecodedHeader header{};
-    fileio::InvalidPacket invalid{ValidationError::buffer_too_small, PacketType::signal_data_no_id,
-                                  header, std::span<const uint8_t>{}};
+    vrtio::InvalidPacket invalid{ValidationError::buffer_too_small, PacketType::signal_data_no_id,
+                                 header, std::span<const uint8_t>{}};
 
     EXPECT_EQ(invalid.error, ValidationError::buffer_too_small);
     EXPECT_FALSE(invalid.error_message().empty());

--- a/tests/io/file_writer_test.cpp
+++ b/tests/io/file_writer_test.cpp
@@ -9,15 +9,18 @@
 #include <gtest/gtest.h>
 #include <vrtio/vrtio_utils.hpp>
 
+// PacketVariant and related types are now in vrtio namespace
 using namespace vrtio::utils::fileio;
 
 // Import specific types from vrtio namespace to avoid ambiguity
 using vrtio::ContextPacket;
 using vrtio::ContextPacketView;
 using vrtio::DataPacketView;
+using vrtio::InvalidPacket;
 using vrtio::NoClassId;
 using vrtio::NoTimeStamp;
 using vrtio::PacketBuilder;
+using vrtio::PacketVariant;
 using vrtio::SignalDataPacket;
 using vrtio::TimeStampUTC;
 using vrtio::Trailer;
@@ -218,7 +221,7 @@ TEST_F(FileWriterTest, RoundTripContextPacket) {
 
     PacketType write_packet(buffer.data());
     write_packet.set_stream_id(test_stream_id);
-    write_packet[vrtio::field::reference_point_id].set_raw_value(test_ref_point);
+    write_packet[vrtio::field::reference_point_id].set_encoded(test_ref_point);
     write_packet[vrtio::field::bandwidth].set_value(1000000.0); // 1 MHz
 
     {

--- a/tests/io/udp_reader_test.cpp
+++ b/tests/io/udp_reader_test.cpp
@@ -14,7 +14,7 @@
 
 using namespace vrtio;
 using namespace vrtio::utils::netio;
-using namespace vrtio::utils::fileio;
+// PacketVariant and related types are now in vrtio namespace
 
 // =============================================================================
 // RAII Thread Guard

--- a/tests/io/udp_writer_test.cpp
+++ b/tests/io/udp_writer_test.cpp
@@ -10,15 +10,16 @@
 #include <vrtio/vrtio_utils.hpp>
 
 using namespace vrtio::utils::netio;
-using namespace vrtio::utils::fileio;
 
 // Import specific types from vrtio namespace to avoid ambiguity
 using vrtio::ContextPacket;
 using vrtio::ContextPacketView;
 using vrtio::DataPacketView;
+using vrtio::InvalidPacket;
 using vrtio::NoClassId;
 using vrtio::NoTimeStamp;
 using vrtio::PacketBuilder;
+using vrtio::PacketVariant;
 using vrtio::SignalDataPacket;
 using vrtio::TimeStampUTC;
 using vrtio::Trailer;
@@ -169,7 +170,7 @@ TEST_F(UDPWriterTest, RoundTripContextPacket) {
 
     PacketType packet(buffer.data());
     packet.set_stream_id(test_stream_id);
-    packet[vrtio::field::reference_point_id].set_raw_value(test_ref_point);
+    packet[vrtio::field::reference_point_id].set_encoded(test_ref_point);
 
     EXPECT_TRUE(writer.write_packet(packet));
 

--- a/tests/security_test.cpp
+++ b/tests/security_test.cpp
@@ -151,10 +151,10 @@ TEST_F(SecurityTest, SizeFieldMismatch) {
     PacketType packet(buffer.data());
 
     // Corrupt size field (bits 15-0) to wrong value
-    corrupt_header_field(buffer.data(), 0x0000FFFF, PacketType::total_words + 1);
+    corrupt_header_field(buffer.data(), 0x0000FFFF, PacketType::size_words + 1);
     EXPECT_EQ(packet.validate(buffer.size()), vrtio::ValidationError::size_field_mismatch);
 
-    corrupt_header_field(buffer.data(), 0x0000FFFF, PacketType::total_words - 1);
+    corrupt_header_field(buffer.data(), 0x0000FFFF, PacketType::size_words - 1);
     EXPECT_EQ(packet.validate(buffer.size()), vrtio::ValidationError::size_field_mismatch);
 
     corrupt_header_field(buffer.data(), 0x0000FFFF, 0);

--- a/tests/signal_packet_view_test.cpp
+++ b/tests/signal_packet_view_test.cpp
@@ -12,7 +12,7 @@ TEST(SignalPacketViewTest, BasicPacketNoStream) {
                                             64                    // 64 words payload
                                             >;
 
-    alignas(4) std::array<uint8_t, PacketType::size_bytes> buffer;
+    alignas(4) std::array<uint8_t, PacketType::size_bytes> buffer{};
     PacketType packet(buffer.data());
 
     // Parse with runtime view
@@ -33,7 +33,7 @@ TEST(SignalPacketViewTest, BasicPacketNoStream) {
 TEST(SignalPacketViewTest, PacketWithStreamID) {
     using PacketType = SignalDataPacket<vrtio::NoClassId, NoTimeStamp, vrtio::Trailer::none, 64>;
 
-    alignas(4) std::array<uint8_t, PacketType::size_bytes> buffer;
+    alignas(4) std::array<uint8_t, PacketType::size_bytes> buffer{};
 
     [[maybe_unused]] auto packet =
         PacketBuilder<PacketType>(buffer.data()).stream_id(0x12345678).build();
@@ -54,7 +54,7 @@ TEST(SignalPacketViewTest, PacketWithStreamID) {
 TEST(SignalPacketViewTest, PacketWithTimestamps) {
     using PacketType = SignalDataPacket<vrtio::NoClassId, TimeStampUTC, vrtio::Trailer::none, 64>;
 
-    alignas(4) std::array<uint8_t, PacketType::size_bytes> buffer;
+    alignas(4) std::array<uint8_t, PacketType::size_bytes> buffer{};
 
     auto ts = TimeStampUTC::from_components(1234567890, 500000000000ULL);
     [[maybe_unused]] auto packet =
@@ -66,8 +66,8 @@ TEST(SignalPacketViewTest, PacketWithTimestamps) {
     EXPECT_TRUE(view.is_valid());
     EXPECT_TRUE(view.has_timestamp_integer());
     EXPECT_TRUE(view.has_timestamp_fractional());
-    EXPECT_EQ(view.tsi(), TsiType::utc);
-    EXPECT_EQ(view.tsf(), TsfType::real_time);
+    EXPECT_EQ(view.tsi_type(), TsiType::utc);
+    EXPECT_EQ(view.tsf_type(), TsfType::real_time);
 
     auto tsi = view.timestamp_integer();
     ASSERT_TRUE(tsi.has_value());
@@ -84,7 +84,7 @@ TEST(SignalPacketViewTest, PacketWithTrailer) {
                                         vrtio::Trailer::included, // has trailer
                                         64>;
 
-    alignas(4) std::array<uint8_t, PacketType::size_bytes> buffer;
+    alignas(4) std::array<uint8_t, PacketType::size_bytes> buffer{};
 
     auto trailer_cfg = vrtio::TrailerBuilder{0xDEADBEEF};
 
@@ -109,7 +109,7 @@ TEST(SignalPacketViewTest, FullFeaturedPacket) {
                                         128                       // larger payload
                                         >;
 
-    alignas(4) std::array<uint8_t, PacketType::size_bytes> buffer;
+    alignas(4) std::array<uint8_t, PacketType::size_bytes> buffer{};
 
     auto ts = TimeStampUTC::from_components(9999999, 123456789012ULL);
     [[maybe_unused]] auto packet = PacketBuilder<PacketType>(buffer.data())
@@ -143,7 +143,7 @@ TEST(SignalPacketViewTest, PayloadAccess) {
                                             16 // 16 words = 64 bytes
                                             >;
 
-    alignas(4) std::array<uint8_t, PacketType::size_bytes> buffer;
+    alignas(4) std::array<uint8_t, PacketType::size_bytes> buffer{};
     PacketType packet(buffer.data());
 
     // Fill payload with test pattern
@@ -173,7 +173,7 @@ TEST(SignalPacketViewTest, ValidationBufferTooSmall) {
     using PacketType =
         SignalDataPacketNoId<vrtio::NoClassId, NoTimeStamp, vrtio::Trailer::none, 64>;
 
-    alignas(4) std::array<uint8_t, PacketType::size_bytes> buffer;
+    alignas(4) std::array<uint8_t, PacketType::size_bytes> buffer{};
     PacketType packet(buffer.data());
 
     // Parse with smaller buffer size
@@ -219,10 +219,10 @@ TEST(SignalPacketViewTest, RoundTripBuildParse) {
         SignalDataPacket<vrtio::NoClassId, TimeStamp<TsiType::gps, TsfType::real_time>,
                          vrtio::Trailer::included, 256>;
 
-    alignas(4) std::array<uint8_t, PacketType::size_bytes> buffer;
+    alignas(4) std::array<uint8_t, PacketType::size_bytes> buffer{};
 
     // Build packet
-    std::array<uint8_t, 256 * 4> payload_data;
+    std::array<uint8_t, 256 * 4> payload_data{};
     for (size_t i = 0; i < payload_data.size(); i++) {
         payload_data[i] = static_cast<uint8_t>((i * 7) & 0xFF);
     }
@@ -249,8 +249,8 @@ TEST(SignalPacketViewTest, RoundTripBuildParse) {
     EXPECT_TRUE(view.has_timestamp_integer());
     EXPECT_TRUE(view.has_timestamp_fractional());
     EXPECT_TRUE(view.has_trailer());
-    EXPECT_EQ(view.tsi(), TsiType::gps);
-    EXPECT_EQ(view.tsf(), TsfType::real_time);
+    EXPECT_EQ(view.tsi_type(), TsiType::gps);
+    EXPECT_EQ(view.tsf_type(), TsfType::real_time);
     EXPECT_EQ(view.packet_count(), 15);
 
     EXPECT_EQ(*view.stream_id(), 0x87654321);

--- a/tests/trailer_test.cpp
+++ b/tests/trailer_test.cpp
@@ -6,537 +6,490 @@
 #include <vrtio.hpp>
 
 // Test fixture for trailer field manipulation
-class TrailerFieldTest : public ::testing::Test {
+class TrailerTest : public ::testing::Test {
 protected:
     using PacketType = vrtio::SignalDataPacket<vrtio::NoClassId, vrtio::TimeStampUTC,
-                                               vrtio::Trailer::included, // Trailer included
-                                               128>;
+                                               vrtio::Trailer::included, 128>;
 
     std::vector<uint8_t> buffer;
 
     void SetUp() override {
         buffer.resize(PacketType::size_bytes);
         PacketType packet(buffer.data());
+        packet.trailer().clear(); // Start with zeroed trailer
     }
 };
 
-// Test individual bit getters and setters
-TEST_F(TrailerFieldTest, ValidDataBit) {
+// ============================================================================
+// Context Packet Count Tests (E bit + 7-bit count)
+// ============================================================================
+
+TEST_F(TrailerTest, ContextPacketCount_InitiallyInvalid) {
     PacketType packet(buffer.data());
 
-    // Initially should be false (trailer is zero-initialized)
-    EXPECT_FALSE(packet.trailer().valid_data());
-
-    // Set to true
-    packet.trailer().set_valid_data(true);
-    EXPECT_TRUE(packet.trailer().valid_data());
-    EXPECT_EQ(packet.trailer().raw(), 1U << 17);
-
-    // Set to false
-    packet.trailer().set_valid_data(false);
-    EXPECT_FALSE(packet.trailer().valid_data());
-    EXPECT_EQ(packet.trailer().raw(), 0U);
+    // When E bit is 0, count should return nullopt
+    EXPECT_FALSE(packet.trailer().context_packet_count().has_value());
 }
 
-TEST_F(TrailerFieldTest, CalibratedTimeBit) {
+TEST_F(TrailerTest, ContextPacketCount_SetAndGet) {
     PacketType packet(buffer.data());
 
-    EXPECT_FALSE(packet.trailer().calibrated_time());
+    // Set count (should set E bit and count field)
+    packet.trailer().set_context_packet_count(42);
+
+    // Should now have a value
+    ASSERT_TRUE(packet.trailer().context_packet_count().has_value());
+    EXPECT_EQ(*packet.trailer().context_packet_count(), 42);
+
+    // E bit (bit 7) should be set
+    EXPECT_TRUE(packet.trailer().raw() & (1U << 7));
+}
+
+TEST_F(TrailerTest, ContextPacketCount_Clear) {
+    PacketType packet(buffer.data());
+
+    packet.trailer().set_context_packet_count(10);
+    ASSERT_TRUE(packet.trailer().context_packet_count().has_value());
+
+    // Clear should set E bit to 0
+    packet.trailer().clear_context_packet_count();
+    EXPECT_FALSE(packet.trailer().context_packet_count().has_value());
+}
+
+TEST_F(TrailerTest, ContextPacketCount_MaxValue) {
+    PacketType packet(buffer.data());
+
+    // Count is 7 bits, max value is 127
+    packet.trailer().set_context_packet_count(127);
+    ASSERT_TRUE(packet.trailer().context_packet_count().has_value());
+    EXPECT_EQ(*packet.trailer().context_packet_count(), 127);
+}
+
+// ============================================================================
+// Named Indicators (8 indicators with enable/indicator bit pairing)
+// ============================================================================
+
+TEST_F(TrailerTest, CalibratedTime_EnableIndicatorPairing) {
+    PacketType packet(buffer.data());
+
+    // Initially invalid (enable bit 31 = 0)
+    EXPECT_FALSE(packet.trailer().calibrated_time().has_value());
+
+    // Set to true (sets enable bit 31 and indicator bit 19)
+    packet.trailer().set_calibrated_time(true);
+    ASSERT_TRUE(packet.trailer().calibrated_time().has_value());
+    EXPECT_TRUE(*packet.trailer().calibrated_time());
+
+    // Verify bits
+    uint32_t raw = packet.trailer().raw();
+    EXPECT_TRUE(raw & (1U << 31)); // Enable bit
+    EXPECT_TRUE(raw & (1U << 19)); // Indicator bit
+
+    // Set to false (enable still set, indicator cleared)
+    packet.trailer().set_calibrated_time(false);
+    ASSERT_TRUE(packet.trailer().calibrated_time().has_value());
+    EXPECT_FALSE(*packet.trailer().calibrated_time());
+
+    raw = packet.trailer().raw();
+    EXPECT_TRUE(raw & (1U << 31));  // Enable still set
+    EXPECT_FALSE(raw & (1U << 19)); // Indicator cleared
+}
+
+TEST_F(TrailerTest, CalibratedTime_Clear) {
+    PacketType packet(buffer.data());
 
     packet.trailer().set_calibrated_time(true);
-    EXPECT_TRUE(packet.trailer().calibrated_time());
-    EXPECT_EQ(packet.trailer().raw(), 1U << 16);
+    ASSERT_TRUE(packet.trailer().calibrated_time().has_value());
 
-    packet.trailer().set_calibrated_time(false);
-    EXPECT_FALSE(packet.trailer().calibrated_time());
+    // Clear should disable the indicator
+    packet.trailer().clear_calibrated_time();
+    EXPECT_FALSE(packet.trailer().calibrated_time().has_value());
+
+    // Enable bit should be cleared
+    EXPECT_FALSE(packet.trailer().raw() & (1U << 31));
 }
 
-TEST_F(TrailerFieldTest, OverRangeBit) {
+TEST_F(TrailerTest, ValidData_EnableIndicatorPairing) {
     PacketType packet(buffer.data());
 
-    EXPECT_FALSE(packet.trailer().over_range());
+    EXPECT_FALSE(packet.trailer().valid_data().has_value());
 
-    packet.trailer().set_over_range(true);
-    EXPECT_TRUE(packet.trailer().over_range());
-    EXPECT_EQ(packet.trailer().raw(), 1U << 12);
+    packet.trailer().set_valid_data(true);
+    ASSERT_TRUE(packet.trailer().valid_data().has_value());
+    EXPECT_TRUE(*packet.trailer().valid_data());
 
-    packet.trailer().set_over_range(false);
-    EXPECT_FALSE(packet.trailer().over_range());
+    // Verify enable bit 30 and indicator bit 18
+    uint32_t raw = packet.trailer().raw();
+    EXPECT_TRUE(raw & (1U << 30));
+    EXPECT_TRUE(raw & (1U << 18));
 }
 
-TEST_F(TrailerFieldTest, SampleLossBit) {
+TEST_F(TrailerTest, ReferenceLock_EnableIndicatorPairing) {
     PacketType packet(buffer.data());
 
-    EXPECT_FALSE(packet.trailer().sample_loss());
-
-    packet.trailer().set_sample_loss(true);
-    EXPECT_TRUE(packet.trailer().sample_loss());
-    EXPECT_EQ(packet.trailer().raw(), 1U << 13);
-}
-
-TEST_F(TrailerFieldTest, ReferenceLockBit) {
-    PacketType packet(buffer.data());
-
-    EXPECT_FALSE(packet.trailer().reference_lock());
+    EXPECT_FALSE(packet.trailer().reference_lock().has_value());
 
     packet.trailer().set_reference_lock(true);
-    EXPECT_TRUE(packet.trailer().reference_lock());
-    EXPECT_EQ(packet.trailer().raw(), 1U << 8);
+    ASSERT_TRUE(packet.trailer().reference_lock().has_value());
+    EXPECT_TRUE(*packet.trailer().reference_lock());
+
+    // Verify enable bit 29 and indicator bit 17
+    uint32_t raw = packet.trailer().raw();
+    EXPECT_TRUE(raw & (1U << 29));
+    EXPECT_TRUE(raw & (1U << 17));
 }
 
-TEST_F(TrailerFieldTest, AgcMgcBit) {
+TEST_F(TrailerTest, AgcMgc_EnableIndicatorPairing) {
     PacketType packet(buffer.data());
 
-    EXPECT_FALSE(packet.trailer().agc_mgc());
+    EXPECT_FALSE(packet.trailer().agc_mgc().has_value());
 
     packet.trailer().set_agc_mgc(true);
-    EXPECT_TRUE(packet.trailer().agc_mgc());
-    EXPECT_EQ(packet.trailer().raw(), 1U << 9);
+    ASSERT_TRUE(packet.trailer().agc_mgc().has_value());
+    EXPECT_TRUE(*packet.trailer().agc_mgc());
+
+    // Verify enable bit 28 and indicator bit 16
+    uint32_t raw = packet.trailer().raw();
+    EXPECT_TRUE(raw & (1U << 28));
+    EXPECT_TRUE(raw & (1U << 16));
 }
 
-TEST_F(TrailerFieldTest, DetectedSignalBit) {
+TEST_F(TrailerTest, DetectedSignal_EnableIndicatorPairing) {
     PacketType packet(buffer.data());
 
-    EXPECT_FALSE(packet.trailer().detected_signal());
+    EXPECT_FALSE(packet.trailer().detected_signal().has_value());
 
     packet.trailer().set_detected_signal(true);
-    EXPECT_TRUE(packet.trailer().detected_signal());
-    EXPECT_EQ(packet.trailer().raw(), 1U << 10);
+    ASSERT_TRUE(packet.trailer().detected_signal().has_value());
+    EXPECT_TRUE(*packet.trailer().detected_signal());
+
+    // Verify enable bit 27 and indicator bit 15
+    uint32_t raw = packet.trailer().raw();
+    EXPECT_TRUE(raw & (1U << 27));
+    EXPECT_TRUE(raw & (1U << 15));
 }
 
-TEST_F(TrailerFieldTest, SpectralInversionBit) {
+TEST_F(TrailerTest, SpectralInversion_EnableIndicatorPairing) {
     PacketType packet(buffer.data());
 
-    EXPECT_FALSE(packet.trailer().spectral_inversion());
+    EXPECT_FALSE(packet.trailer().spectral_inversion().has_value());
 
     packet.trailer().set_spectral_inversion(true);
-    EXPECT_TRUE(packet.trailer().spectral_inversion());
-    EXPECT_EQ(packet.trailer().raw(), 1U << 11);
+    ASSERT_TRUE(packet.trailer().spectral_inversion().has_value());
+    EXPECT_TRUE(*packet.trailer().spectral_inversion());
+
+    // Verify enable bit 26 and indicator bit 14
+    uint32_t raw = packet.trailer().raw();
+    EXPECT_TRUE(raw & (1U << 26));
+    EXPECT_TRUE(raw & (1U << 14));
 }
 
-TEST_F(TrailerFieldTest, ReferencePointBit) {
+TEST_F(TrailerTest, OverRange_EnableIndicatorPairing) {
     PacketType packet(buffer.data());
 
-    EXPECT_FALSE(packet.trailer().reference_point());
+    EXPECT_FALSE(packet.trailer().over_range().has_value());
 
-    packet.trailer().set_reference_point(true);
-    EXPECT_TRUE(packet.trailer().reference_point());
-    EXPECT_EQ(packet.trailer().raw(), 1U << 18);
-}
-
-TEST_F(TrailerFieldTest, SignalDetectedBit) {
-    PacketType packet(buffer.data());
-
-    EXPECT_FALSE(packet.trailer().signal_detected());
-
-    packet.trailer().set_signal_detected(true);
-    EXPECT_TRUE(packet.trailer().signal_detected());
-    EXPECT_EQ(packet.trailer().raw(), 1U << 19);
-}
-
-TEST_F(TrailerFieldTest, ContextPacketsField) {
-    PacketType packet(buffer.data());
-
-    EXPECT_EQ(packet.trailer().context_packets(), 0);
-
-    // Set to various values
-    packet.trailer().set_context_packets(5);
-    EXPECT_EQ(packet.trailer().context_packets(), 5);
-    EXPECT_EQ(packet.trailer().raw(), 5U);
-
-    packet.trailer().set_context_packets(127);
-    EXPECT_EQ(packet.trailer().context_packets(), 127);
-    EXPECT_EQ(packet.trailer().raw(), 127U);
-
-    packet.trailer().set_context_packets(0);
-    EXPECT_EQ(packet.trailer().context_packets(), 0);
-}
-
-// Test multiple bits set simultaneously
-TEST_F(TrailerFieldTest, MultipleBitsSet) {
-    PacketType packet(buffer.data());
-
-    packet.trailer().set_valid_data(true);
-    packet.trailer().set_calibrated_time(true);
-
-    EXPECT_TRUE(packet.trailer().valid_data());
-    EXPECT_TRUE(packet.trailer().calibrated_time());
-
-    uint32_t expected = (1U << 17) | (1U << 16);
-    EXPECT_EQ(packet.trailer().raw(), expected);
-}
-
-TEST_F(TrailerFieldTest, ErrorFlags) {
-    PacketType packet(buffer.data());
-
-    // No errors initially
-    EXPECT_FALSE(packet.trailer().has_errors());
-
-    // Set over-range
     packet.trailer().set_over_range(true);
-    EXPECT_TRUE(packet.trailer().has_errors());
+    ASSERT_TRUE(packet.trailer().over_range().has_value());
+    EXPECT_TRUE(*packet.trailer().over_range());
 
-    // Clear over-range, set sample loss
-    packet.trailer().set_over_range(false);
+    // Verify enable bit 25 and indicator bit 13
+    uint32_t raw = packet.trailer().raw();
+    EXPECT_TRUE(raw & (1U << 25));
+    EXPECT_TRUE(raw & (1U << 13));
+}
+
+TEST_F(TrailerTest, SampleLoss_EnableIndicatorPairing) {
+    PacketType packet(buffer.data());
+
+    EXPECT_FALSE(packet.trailer().sample_loss().has_value());
+
     packet.trailer().set_sample_loss(true);
-    EXPECT_TRUE(packet.trailer().has_errors());
+    ASSERT_TRUE(packet.trailer().sample_loss().has_value());
+    EXPECT_TRUE(*packet.trailer().sample_loss());
 
-    // Both errors
-    packet.trailer().set_over_range(true);
-    EXPECT_TRUE(packet.trailer().has_errors());
-
-    // Clear all errors
-    packet.trailer().set_over_range(false);
-    packet.trailer().set_sample_loss(false);
-    EXPECT_FALSE(packet.trailer().has_errors());
+    // Verify enable bit 24 and indicator bit 12
+    uint32_t raw = packet.trailer().raw();
+    EXPECT_TRUE(raw & (1U << 24));
+    EXPECT_TRUE(raw & (1U << 12));
 }
 
-TEST_F(TrailerFieldTest, GoodStatus) {
+// ============================================================================
+// Sample Frame and User-Defined Indicators (bits 11-8, no enable bits)
+// ============================================================================
+
+TEST_F(TrailerTest, SampleFrame1_DirectAccess) {
     PacketType packet(buffer.data());
 
-    packet.trailer().set_valid_data(true);
-    packet.trailer().set_calibrated_time(true);
+    // Initially false
+    EXPECT_FALSE(packet.trailer().sample_frame_1());
 
-    EXPECT_TRUE(packet.trailer().valid_data());
-    EXPECT_TRUE(packet.trailer().calibrated_time());
-    EXPECT_EQ(packet.trailer().raw(), vrtio::trailer::status_all_good);
+    // Set to true
+    packet.trailer().set_sample_frame_1(true);
+    EXPECT_TRUE(packet.trailer().sample_frame_1());
+    EXPECT_TRUE(packet.trailer().raw() & (1U << 11));
+
+    // Set to false
+    packet.trailer().set_sample_frame_1(false);
+    EXPECT_FALSE(packet.trailer().sample_frame_1());
 }
 
-TEST_F(TrailerFieldTest, ClearTrailer) {
+TEST_F(TrailerTest, SampleFrame0_DirectAccess) {
     PacketType packet(buffer.data());
 
-    // Set multiple bits
-    packet.trailer().set_valid_data(true);
+    EXPECT_FALSE(packet.trailer().sample_frame_0());
+
+    packet.trailer().set_sample_frame_0(true);
+    EXPECT_TRUE(packet.trailer().sample_frame_0());
+    EXPECT_TRUE(packet.trailer().raw() & (1U << 10));
+
+    packet.trailer().clear_sample_frame_0();
+    EXPECT_FALSE(packet.trailer().sample_frame_0());
+}
+
+TEST_F(TrailerTest, UserDefined1_DirectAccess) {
+    PacketType packet(buffer.data());
+
+    EXPECT_FALSE(packet.trailer().user_defined_1());
+
+    packet.trailer().set_user_defined_1(true);
+    EXPECT_TRUE(packet.trailer().user_defined_1());
+    EXPECT_TRUE(packet.trailer().raw() & (1U << 9));
+
+    packet.trailer().clear_user_defined_1();
+    EXPECT_FALSE(packet.trailer().user_defined_1());
+}
+
+TEST_F(TrailerTest, UserDefined0_DirectAccess) {
+    PacketType packet(buffer.data());
+
+    EXPECT_FALSE(packet.trailer().user_defined_0());
+
+    packet.trailer().set_user_defined_0(true);
+    EXPECT_TRUE(packet.trailer().user_defined_0());
+    EXPECT_TRUE(packet.trailer().raw() & (1U << 8));
+
+    packet.trailer().clear_user_defined_0();
+    EXPECT_FALSE(packet.trailer().user_defined_0());
+}
+
+// ============================================================================
+// TrailerBuilder Tests
+// ============================================================================
+
+TEST_F(TrailerTest, Builder_ContextPacketCount) {
+    PacketType packet(buffer.data());
+
+    vrtio::TrailerBuilder().context_packet_count(25).apply(packet.trailer());
+
+    ASSERT_TRUE(packet.trailer().context_packet_count().has_value());
+    EXPECT_EQ(*packet.trailer().context_packet_count(), 25);
+}
+
+TEST_F(TrailerTest, Builder_NamedIndicators) {
+    PacketType packet(buffer.data());
+
+    vrtio::TrailerBuilder().calibrated_time(true).valid_data(true).reference_lock(false).apply(
+        packet.trailer());
+
+    ASSERT_TRUE(packet.trailer().calibrated_time().has_value());
+    EXPECT_TRUE(*packet.trailer().calibrated_time());
+
+    ASSERT_TRUE(packet.trailer().valid_data().has_value());
+    EXPECT_TRUE(*packet.trailer().valid_data());
+
+    ASSERT_TRUE(packet.trailer().reference_lock().has_value());
+    EXPECT_FALSE(*packet.trailer().reference_lock());
+}
+
+TEST_F(TrailerTest, Builder_SampleFrameAndUserDefined) {
+    PacketType packet(buffer.data());
+
+    vrtio::TrailerBuilder()
+        .sample_frame_1(true)
+        .sample_frame_0(false)
+        .user_defined_1(true)
+        .user_defined_0(false)
+        .apply(packet.trailer());
+
+    EXPECT_TRUE(packet.trailer().sample_frame_1());
+    EXPECT_FALSE(packet.trailer().sample_frame_0());
+    EXPECT_TRUE(packet.trailer().user_defined_1());
+    EXPECT_FALSE(packet.trailer().user_defined_0());
+}
+
+TEST_F(TrailerTest, Builder_ComplexTrailer) {
+    PacketType packet(buffer.data());
+
+    vrtio::TrailerBuilder()
+        .context_packet_count(10)
+        .calibrated_time(true)
+        .valid_data(true)
+        .over_range(false)
+        .sample_loss(false)
+        .sample_frame_1(true)
+        .apply(packet.trailer());
+
+    ASSERT_TRUE(packet.trailer().context_packet_count().has_value());
+    EXPECT_EQ(*packet.trailer().context_packet_count(), 10);
+
+    ASSERT_TRUE(packet.trailer().calibrated_time().has_value());
+    EXPECT_TRUE(*packet.trailer().calibrated_time());
+
+    ASSERT_TRUE(packet.trailer().valid_data().has_value());
+    EXPECT_TRUE(*packet.trailer().valid_data());
+
+    ASSERT_TRUE(packet.trailer().over_range().has_value());
+    EXPECT_FALSE(*packet.trailer().over_range());
+
+    EXPECT_TRUE(packet.trailer().sample_frame_1());
+}
+
+TEST_F(TrailerTest, Builder_ValueMethod) {
+    uint32_t trailer_word = vrtio::TrailerBuilder().calibrated_time(true).valid_data(true).value();
+
+    // Should have enable bits 31,30 and indicator bits 19,18
+    EXPECT_TRUE(trailer_word & (1U << 31));
+    EXPECT_TRUE(trailer_word & (1U << 30));
+    EXPECT_TRUE(trailer_word & (1U << 19));
+    EXPECT_TRUE(trailer_word & (1U << 18));
+}
+
+TEST_F(TrailerTest, Builder_FromView) {
+    PacketType packet(buffer.data());
+
+    // Set up trailer
     packet.trailer().set_calibrated_time(true);
-    packet.trailer().set_over_range(true);
+    packet.trailer().set_context_packet_count(42);
 
-    EXPECT_NE(packet.trailer().raw(), 0U);
+    // Copy to builder and modify
+    auto new_trailer = vrtio::TrailerBuilder().from_view(packet.trailer()).valid_data(true).value();
 
-    // Clear
+    // Should have original values plus new one
+    PacketType packet2(buffer.data());
+    packet2.trailer().set_raw(new_trailer);
+
+    ASSERT_TRUE(packet2.trailer().calibrated_time().has_value());
+    EXPECT_TRUE(*packet2.trailer().calibrated_time());
+
+    ASSERT_TRUE(packet2.trailer().context_packet_count().has_value());
+    EXPECT_EQ(*packet2.trailer().context_packet_count(), 42);
+
+    ASSERT_TRUE(packet2.trailer().valid_data().has_value());
+    EXPECT_TRUE(*packet2.trailer().valid_data());
+}
+
+// ============================================================================
+// Clear Methods Tests
+// ============================================================================
+
+TEST_F(TrailerTest, ClearMethods_NamedIndicators) {
+    PacketType packet(buffer.data());
+
+    // Set multiple indicators
+    packet.trailer().set_calibrated_time(true);
+    packet.trailer().set_valid_data(true);
+    packet.trailer().set_reference_lock(true);
+
+    // Clear one
+    packet.trailer().clear_valid_data();
+
+    // Others should still be set
+    ASSERT_TRUE(packet.trailer().calibrated_time().has_value());
+    EXPECT_TRUE(*packet.trailer().calibrated_time());
+
+    ASSERT_TRUE(packet.trailer().reference_lock().has_value());
+    EXPECT_TRUE(*packet.trailer().reference_lock());
+
+    // Cleared one should return nullopt
+    EXPECT_FALSE(packet.trailer().valid_data().has_value());
+}
+
+TEST_F(TrailerTest, ClearMethod_EntireTrailer) {
+    PacketType packet(buffer.data());
+
+    // Set everything
+    packet.trailer().set_context_packet_count(50);
+    packet.trailer().set_calibrated_time(true);
+    packet.trailer().set_valid_data(true);
+    packet.trailer().set_sample_frame_1(true);
+
+    // Clear entire trailer
     packet.trailer().clear();
+
+    // Everything should be invalid/false
+    EXPECT_FALSE(packet.trailer().context_packet_count().has_value());
+    EXPECT_FALSE(packet.trailer().calibrated_time().has_value());
+    EXPECT_FALSE(packet.trailer().valid_data().has_value());
+    EXPECT_FALSE(packet.trailer().sample_frame_1());
     EXPECT_EQ(packet.trailer().raw(), 0U);
-    EXPECT_FALSE(packet.trailer().valid_data());
-    EXPECT_FALSE(packet.trailer().calibrated_time());
-    EXPECT_FALSE(packet.trailer().over_range());
 }
 
-// Test that setting one bit doesn't affect others
-TEST_F(TrailerFieldTest, BitIndependence) {
+// ============================================================================
+// Multiple Indicators Test
+// ============================================================================
+
+TEST_F(TrailerTest, MultipleIndicators_Independent) {
     PacketType packet(buffer.data());
 
-    // Set multiple bits
-    packet.trailer().set_valid_data(true);
-    packet.trailer().set_context_packets(42);
-    packet.trailer().set_over_range(true);
-
-    // Verify initial state
-    EXPECT_TRUE(packet.trailer().valid_data());
-    EXPECT_EQ(packet.trailer().context_packets(), 42);
-    EXPECT_TRUE(packet.trailer().over_range());
-
-    // Toggle one bit
+    // Set multiple indicators independently
     packet.trailer().set_calibrated_time(true);
+    packet.trailer().set_valid_data(false);
+    packet.trailer().set_over_range(true);
+    packet.trailer().set_sample_loss(false);
+    packet.trailer().set_context_packet_count(7);
 
-    // Verify others unchanged
-    EXPECT_TRUE(packet.trailer().valid_data());
-    EXPECT_EQ(packet.trailer().context_packets(), 42);
-    EXPECT_TRUE(packet.trailer().over_range());
-    EXPECT_TRUE(packet.trailer().calibrated_time());
+    // All should be independently accessible
+    ASSERT_TRUE(packet.trailer().calibrated_time().has_value());
+    EXPECT_TRUE(*packet.trailer().calibrated_time());
 
-    // Clear one bit
-    packet.trailer().set_over_range(false);
+    ASSERT_TRUE(packet.trailer().valid_data().has_value());
+    EXPECT_FALSE(*packet.trailer().valid_data());
 
-    // Verify others unchanged
-    EXPECT_TRUE(packet.trailer().valid_data());
-    EXPECT_EQ(packet.trailer().context_packets(), 42);
-    EXPECT_FALSE(packet.trailer().over_range());
-    EXPECT_TRUE(packet.trailer().calibrated_time());
+    ASSERT_TRUE(packet.trailer().over_range().has_value());
+    EXPECT_TRUE(*packet.trailer().over_range());
+
+    ASSERT_TRUE(packet.trailer().sample_loss().has_value());
+    EXPECT_FALSE(*packet.trailer().sample_loss());
+
+    ASSERT_TRUE(packet.trailer().context_packet_count().has_value());
+    EXPECT_EQ(*packet.trailer().context_packet_count(), 7);
 }
 
-// Test builder pattern with individual fields
-TEST_F(TrailerFieldTest, BuilderIndividualFields) {
-    auto ts = vrtio::TimeStampUTC::from_components(1000000, 0);
-    auto packet = vrtio::PacketBuilder<PacketType>(buffer.data())
-                      .stream_id(0x12345678)
-                      .timestamp(ts)
-                      .trailer_valid_data(true)
-                      .trailer_calibrated_time(true)
-                      .packet_count(12) // Max 15 (4 bits)
-                      .build();
+// ============================================================================
+// Endian Test
+// ============================================================================
 
-    EXPECT_EQ(packet.stream_id(), 0x12345678U);
-    auto read_ts = packet.timestamp();
-    EXPECT_EQ(read_ts.seconds(), 1000000U);
-    EXPECT_TRUE(packet.trailer().valid_data());
-    EXPECT_TRUE(packet.trailer().calibrated_time());
-    EXPECT_EQ(packet.packet_count(), 12);
-}
-
-TEST_F(TrailerFieldTest, BuilderGoodStatus) {
-    auto packet = vrtio::PacketBuilder<PacketType>(buffer.data())
-                      .stream_id(0x11111111)
-                      .trailer_valid_data(true)
-                      .trailer_calibrated_time(true)
-                      .build();
-
-    EXPECT_TRUE(packet.trailer().valid_data());
-    EXPECT_TRUE(packet.trailer().calibrated_time());
-    EXPECT_EQ(packet.trailer().raw(), vrtio::trailer::status_all_good);
-}
-
-TEST_F(TrailerFieldTest, BuilderWithErrors) {
-    auto packet = vrtio::PacketBuilder<PacketType>(buffer.data())
-                      .stream_id(0x33333333)
-                      .trailer_valid_data(true)
-                      .trailer_calibrated_time(true)
-                      .trailer_over_range(true)
-                      .trailer_sample_loss(true)
-                      .build();
-
-    EXPECT_TRUE(packet.trailer().valid_data());
-    EXPECT_TRUE(packet.trailer().calibrated_time());
-    EXPECT_TRUE(packet.trailer().over_range());
-    EXPECT_TRUE(packet.trailer().sample_loss());
-    EXPECT_TRUE(packet.trailer().has_errors());
-}
-
-TEST_F(TrailerFieldTest, BuilderContextPackets) {
-    auto packet = vrtio::PacketBuilder<PacketType>(buffer.data())
-                      .stream_id(0x44444444)
-                      .trailer_context_packets(10)
-                      .trailer_valid_data(true)
-                      .build();
-
-    EXPECT_EQ(packet.trailer().context_packets(), 10);
-    EXPECT_TRUE(packet.trailer().valid_data());
-}
-
-TEST_F(TrailerFieldTest, BuilderReferenceLock) {
-    auto packet = vrtio::PacketBuilder<PacketType>(buffer.data())
-                      .stream_id(0x55555555)
-                      .trailer_reference_lock(true)
-                      .trailer_valid_data(true)
-                      .build();
-
-    EXPECT_TRUE(packet.trailer().reference_lock());
-    EXPECT_TRUE(packet.trailer().valid_data());
-}
-
-// Test network byte order preservation
-TEST_F(TrailerFieldTest, NetworkByteOrder) {
+TEST_F(TrailerTest, EndianHandling) {
     PacketType packet(buffer.data());
 
-    // Set a specific trailer pattern
-    uint32_t test_value = 0x12345678;
-    packet.trailer().set_raw(test_value);
+    packet.trailer().set_calibrated_time(true);
+    packet.trailer().set_context_packet_count(42);
 
-    // Read it back
-    EXPECT_EQ(packet.trailer().raw(), test_value);
+    // Read back should work correctly (verifies endian handling)
+    ASSERT_TRUE(packet.trailer().calibrated_time().has_value());
+    EXPECT_TRUE(*packet.trailer().calibrated_time());
 
-    // Verify individual bits work correctly with this value
-    // Bit 16 should be set (0x00010000 is part of 0x12345678)
-    // Actually 0x12345678 has bits: 28,24,22,20,18,14,12,11,10,6,5,4,3
-    bool bit16 = (test_value >> 16) & 0x01;
-    EXPECT_EQ(packet.trailer().calibrated_time(), bit16);
+    ASSERT_TRUE(packet.trailer().context_packet_count().has_value());
+    EXPECT_EQ(*packet.trailer().context_packet_count(), 42);
 }
 
-// Test constexpr helper functions directly
-TEST(TrailerHelperTest, ExtractBit) {
-    uint32_t value = 0x00030000; // Bits 16 and 17 set
+// ============================================================================
+// VITA 49.2 Rule 5.1.6-13 Compliance
+// ============================================================================
 
-    EXPECT_TRUE(vrtio::trailer::extract_bit<16>(value));
-    EXPECT_TRUE(vrtio::trailer::extract_bit<17>(value));
-    EXPECT_FALSE(vrtio::trailer::extract_bit<15>(value));
-    EXPECT_FALSE(vrtio::trailer::extract_bit<18>(value));
-}
-
-TEST(TrailerHelperTest, SetBit) {
-    uint32_t value = 0;
-
-    value = vrtio::trailer::set_bit<17>(value, true);
-    EXPECT_EQ(value, 1U << 17);
-
-    value = vrtio::trailer::set_bit<16>(value, true);
-    EXPECT_EQ(value, (1U << 17) | (1U << 16));
-
-    value = vrtio::trailer::set_bit<17>(value, false);
-    EXPECT_EQ(value, 1U << 16);
-}
-
-TEST(TrailerHelperTest, ExtractField) {
-    uint32_t value = 0x0000007F; // Context packets = 127
-
-    uint32_t field = vrtio::trailer::extract_field<vrtio::trailer::context_packets_shift,
-                                                   vrtio::trailer::context_packets_mask>(value);
-
-    EXPECT_EQ(field, 127U);
-}
-
-TEST(TrailerHelperTest, SetField) {
-    uint32_t value = 0;
-
-    value = vrtio::trailer::set_field<vrtio::trailer::context_packets_shift,
-                                      vrtio::trailer::context_packets_mask>(value, 42);
-
-    EXPECT_EQ(value, 42U);
-
-    // Verify it doesn't affect other bits
-    value = 0xFFFFFFFF;
-    value = vrtio::trailer::set_field<vrtio::trailer::context_packets_shift,
-                                      vrtio::trailer::context_packets_mask>(value, 0);
-
-    EXPECT_EQ(value & 0x7F, 0U);
-    EXPECT_EQ(value & ~0x7FU, 0xFFFFFF80U);
-}
-
-TEST(TrailerHelperTest, IsValidData) {
-    EXPECT_FALSE(vrtio::trailer::is_valid_data(0));
-    EXPECT_TRUE(vrtio::trailer::is_valid_data(1U << 17));
-    EXPECT_TRUE(vrtio::trailer::is_valid_data(0xFFFFFFFF));
-}
-
-TEST(TrailerHelperTest, IsCalibratedTime) {
-    EXPECT_FALSE(vrtio::trailer::is_calibrated_time(0));
-    EXPECT_TRUE(vrtio::trailer::is_calibrated_time(1U << 16));
-    EXPECT_TRUE(vrtio::trailer::is_calibrated_time(0xFFFFFFFF));
-}
-
-TEST(TrailerHelperTest, HasErrors) {
-    EXPECT_FALSE(vrtio::trailer::has_errors(0));
-    EXPECT_TRUE(vrtio::trailer::has_errors(1U << 12)); // over-range
-    EXPECT_TRUE(vrtio::trailer::has_errors(1U << 13)); // sample loss
-    EXPECT_TRUE(vrtio::trailer::has_errors((1U << 12) | (1U << 13)));
-    EXPECT_FALSE(vrtio::trailer::has_errors((1U << 16) | (1U << 17))); // good status
-}
-
-TEST(TrailerHelperTest, ExtractContextPackets) {
-    EXPECT_EQ(vrtio::trailer::extract_context_packets(0), 0);
-    EXPECT_EQ(vrtio::trailer::extract_context_packets(42), 42);
-    EXPECT_EQ(vrtio::trailer::extract_context_packets(127), 127);
-    EXPECT_EQ(vrtio::trailer::extract_context_packets(0xFFFFFFFF), 127); // Masked to 7 bits
-}
-
-TEST(TrailerHelperTest, CreateGoodStatus) {
-    uint32_t status = vrtio::trailer::create_good_status();
-    EXPECT_EQ(status, (1U << 17) | (1U << 16));
-    EXPECT_TRUE(vrtio::trailer::is_valid_data(status));
-    EXPECT_TRUE(vrtio::trailer::is_calibrated_time(status));
-    EXPECT_FALSE(vrtio::trailer::has_errors(status));
-}
-
-TEST(TrailerViewTest, MutableViewUpdatesBuffer) {
-    alignas(4) std::array<uint8_t, 4> buffer{};
-    vrtio::TrailerView view(buffer.data());
-    EXPECT_EQ(view.raw(), 0U);
-    view.set_valid_data(true);
-    view.set_calibrated_time(true);
-    EXPECT_TRUE(view.valid_data());
-    EXPECT_TRUE(view.calibrated_time());
-
-    vrtio::ConstTrailerView const_view(buffer.data());
-    EXPECT_TRUE(const_view.valid_data());
-    EXPECT_TRUE(const_view.calibrated_time());
-}
-
-TEST(TrailerViewTest, StatusHelpers) {
-    alignas(4) std::array<uint8_t, 4> buffer{};
-    vrtio::TrailerView view(buffer.data());
-    view.set_valid_data(true);
-    view.set_calibrated_time(true);
-    view.set_over_range(true);
-    view.set_sample_loss(false);
-    EXPECT_TRUE(view.valid_data());
-    EXPECT_TRUE(view.calibrated_time());
-    EXPECT_TRUE(view.over_range());
-    EXPECT_FALSE(view.sample_loss());
-
-    view.clear();
-    EXPECT_EQ(view.raw(), 0U);
-    view.set_valid_data(true);
-    view.set_calibrated_time(true);
-    EXPECT_EQ(view.raw(), vrtio::trailer::status_all_good);
-}
-
-TEST(TrailerBuilderTest, FluentValue) {
-    auto builder = vrtio::TrailerBuilder{}
-                       .valid_data(true)
-                       .calibrated_time(true)
-                       .context_packets(12)
-                       .over_range(true);
-
-    alignas(4) std::array<uint8_t, 4> buffer{};
-    builder.apply(vrtio::TrailerView(buffer.data()));
-
-    vrtio::ConstTrailerView view(buffer.data());
-    EXPECT_TRUE(view.valid_data());
-    EXPECT_TRUE(view.calibrated_time());
-    EXPECT_EQ(view.context_packets(), 12);
-    EXPECT_TRUE(view.over_range());
-    EXPECT_TRUE(view.has_errors());
-}
-
-// Test edge cases
-TEST_F(TrailerFieldTest, ContextPacketsBoundary) {
+TEST_F(TrailerTest, Rule_5_1_6_13_Compliance) {
     PacketType packet(buffer.data());
 
-    // Test maximum value (7 bits = 127)
-    packet.trailer().set_context_packets(127);
-    EXPECT_EQ(packet.trailer().context_packets(), 127);
+    // Rule 5.1.6-13: When E bit is 0, count is undefined
+    EXPECT_FALSE(packet.trailer().context_packet_count().has_value());
 
-    // Test that values > 127 are masked (truncated to 7 bits)
-    packet.trailer().set_context_packets(128);
-    EXPECT_EQ(packet.trailer().context_packets(), 0); // 128 & 0x7F = 0
+    // When E bit is 1, count shall be valid
+    packet.trailer().set_context_packet_count(100);
+    ASSERT_TRUE(packet.trailer().context_packet_count().has_value());
+    EXPECT_EQ(*packet.trailer().context_packet_count(), 100);
 
-    packet.trailer().set_context_packets(255);
-    EXPECT_EQ(packet.trailer().context_packets(), 127); // 255 & 0x7F = 127
-}
-
-TEST_F(TrailerFieldTest, AllBitsSet) {
-    PacketType packet(buffer.data());
-
-    // Set all defined bits
-    packet.trailer().set_raw(0xFFFFFFFF);
-
-    // Verify all getters return true/max value
-    EXPECT_EQ(packet.trailer().context_packets(), 127);
-    EXPECT_TRUE(packet.trailer().reference_lock());
-    EXPECT_TRUE(packet.trailer().agc_mgc());
-    EXPECT_TRUE(packet.trailer().detected_signal());
-    EXPECT_TRUE(packet.trailer().spectral_inversion());
-    EXPECT_TRUE(packet.trailer().over_range());
-    EXPECT_TRUE(packet.trailer().sample_loss());
-    EXPECT_TRUE(packet.trailer().calibrated_time());
-    EXPECT_TRUE(packet.trailer().valid_data());
-    EXPECT_TRUE(packet.trailer().reference_point());
-    EXPECT_TRUE(packet.trailer().signal_detected());
-    EXPECT_TRUE(packet.trailer().has_errors());
-}
-
-// Test roundtrip through serialization
-TEST_F(TrailerFieldTest, SerializationRoundtrip) {
-    // Create and configure packet
-    auto ts = vrtio::TimeStampUTC::from_components(999999, 0);
-    [[maybe_unused]] auto packet1 = vrtio::PacketBuilder<PacketType>(buffer.data())
-                                        .stream_id(0xABCDEF00)
-                                        .timestamp(ts)
-                                        .trailer_valid_data(true)
-                                        .trailer_calibrated_time(true)
-                                        .trailer_context_packets(25)
-                                        .trailer_reference_lock(true)
-                                        .packet_count(10)
-                                        .build();
-
-    // Simulate receiving: parse into a new buffer
-    std::vector<uint8_t> rx_buffer(buffer.begin(), buffer.end());
-    PacketType packet2(rx_buffer.data(), false);
-
-    // Verify all fields match
-    EXPECT_EQ(packet2.stream_id(), 0xABCDEF00U);
-    auto read_ts = packet2.timestamp();
-    EXPECT_EQ(read_ts.seconds(), 999999U);
-    EXPECT_TRUE(packet2.trailer().valid_data());
-    EXPECT_TRUE(packet2.trailer().calibrated_time());
-    EXPECT_EQ(packet2.trailer().context_packets(), 25);
-    EXPECT_TRUE(packet2.trailer().reference_lock());
-    EXPECT_EQ(packet2.packet_count(), 10);
+    // Clearing E bit makes count undefined again
+    packet.trailer().clear_context_packet_count();
+    EXPECT_FALSE(packet.trailer().context_packet_count().has_value());
 }


### PR DESCRIPTION
* Cleaned up packet size and type accessors
* Fix packet count API
* Make parse_packet public
* Normalize header access
* Header indicator bit handling
* Naming consistency
* Normalizing presence queries
* Rename FieldProxy methods
* Rename trailer views for consistency
* Re-wrote trailer view
* Fix formatting