### PR TITLE
feat: add from_seconds/ms/us/ns factories to ShortDuration

### DIFF
--- a/include/vrtigo/duration.hpp
+++ b/include/vrtigo/duration.hpp
@@ -390,6 +390,54 @@ public:
         return ShortDuration(ps);
     }
 
+    static constexpr ShortDuration from_nanoseconds(int64_t ns) noexcept {
+        constexpr int64_t MAX_SAFE_NS = std::numeric_limits<int64_t>::max() /
+                                        static_cast<int64_t>(Duration::PICOSECONDS_PER_NANOSECOND);
+        constexpr int64_t MIN_SAFE_NS = std::numeric_limits<int64_t>::min() /
+                                        static_cast<int64_t>(Duration::PICOSECONDS_PER_NANOSECOND);
+        if (ns > MAX_SAFE_NS)
+            return max();
+        if (ns < MIN_SAFE_NS)
+            return min();
+        return from_picoseconds(ns * static_cast<int64_t>(Duration::PICOSECONDS_PER_NANOSECOND));
+    }
+
+    static constexpr ShortDuration from_microseconds(int64_t us) noexcept {
+        constexpr int64_t MAX_SAFE_US = std::numeric_limits<int64_t>::max() /
+                                        static_cast<int64_t>(Duration::PICOSECONDS_PER_MICROSECOND);
+        constexpr int64_t MIN_SAFE_US = std::numeric_limits<int64_t>::min() /
+                                        static_cast<int64_t>(Duration::PICOSECONDS_PER_MICROSECOND);
+        if (us > MAX_SAFE_US)
+            return max();
+        if (us < MIN_SAFE_US)
+            return min();
+        return from_picoseconds(us * static_cast<int64_t>(Duration::PICOSECONDS_PER_MICROSECOND));
+    }
+
+    static constexpr ShortDuration from_milliseconds(int64_t ms) noexcept {
+        constexpr int64_t MAX_SAFE_MS = std::numeric_limits<int64_t>::max() /
+                                        static_cast<int64_t>(Duration::PICOSECONDS_PER_MILLISECOND);
+        constexpr int64_t MIN_SAFE_MS = std::numeric_limits<int64_t>::min() /
+                                        static_cast<int64_t>(Duration::PICOSECONDS_PER_MILLISECOND);
+        if (ms > MAX_SAFE_MS)
+            return max();
+        if (ms < MIN_SAFE_MS)
+            return min();
+        return from_picoseconds(ms * static_cast<int64_t>(Duration::PICOSECONDS_PER_MILLISECOND));
+    }
+
+    static constexpr ShortDuration from_seconds(int64_t s) noexcept {
+        constexpr int64_t MAX_SAFE_S =
+            std::numeric_limits<int64_t>::max() / static_cast<int64_t>(PICOS_PER_SEC);
+        constexpr int64_t MIN_SAFE_S =
+            std::numeric_limits<int64_t>::min() / static_cast<int64_t>(PICOS_PER_SEC);
+        if (s > MAX_SAFE_S)
+            return max();
+        if (s < MIN_SAFE_S)
+            return min();
+        return from_picoseconds(s * static_cast<int64_t>(PICOS_PER_SEC));
+    }
+
     // Convert from Duration - saturates if Duration exceeds ±106 days
     static constexpr ShortDuration from_duration(Duration d) noexcept {
         return ShortDuration(d.total_picoseconds()); // total_picoseconds() already saturates

--- a/tests/duration_test.cpp
+++ b/tests/duration_test.cpp
@@ -771,6 +771,150 @@ TEST_F(DurationTest, ShortDurationFromPicoseconds) {
     EXPECT_TRUE(d.is_positive());
 }
 
+TEST_F(DurationTest, ShortDurationFromNanoseconds) {
+    auto d = ShortDuration::from_nanoseconds(100);
+    EXPECT_EQ(d.picoseconds(), 100 * ONE_NS_PICOS);
+}
+
+TEST_F(DurationTest, ShortDurationFromNanosecondsNegative) {
+    auto d = ShortDuration::from_nanoseconds(-100);
+    EXPECT_EQ(d.picoseconds(), -100 * ONE_NS_PICOS);
+}
+
+TEST_F(DurationTest, ShortDurationFromNanosecondsOverflowSaturates) {
+    auto d = ShortDuration::from_nanoseconds(std::numeric_limits<int64_t>::max());
+    EXPECT_EQ(d, ShortDuration::max());
+    EXPECT_TRUE(saturated(d));
+}
+
+TEST_F(DurationTest, ShortDurationFromNanosecondsUnderflowSaturates) {
+    auto d = ShortDuration::from_nanoseconds(std::numeric_limits<int64_t>::min());
+    EXPECT_EQ(d, ShortDuration::min());
+    EXPECT_TRUE(saturated(d));
+}
+
+TEST_F(DurationTest, ShortDurationFromMicroseconds) {
+    auto d = ShortDuration::from_microseconds(5);
+    EXPECT_EQ(d.picoseconds(), 5 * ONE_US_PICOS);
+}
+
+TEST_F(DurationTest, ShortDurationFromMicrosecondsNegative) {
+    auto d = ShortDuration::from_microseconds(-5);
+    EXPECT_EQ(d.picoseconds(), -5 * ONE_US_PICOS);
+}
+
+TEST_F(DurationTest, ShortDurationFromMicrosecondsOverflowSaturates) {
+    auto d = ShortDuration::from_microseconds(std::numeric_limits<int64_t>::max());
+    EXPECT_EQ(d, ShortDuration::max());
+}
+
+TEST_F(DurationTest, ShortDurationFromMicrosecondsUnderflowSaturates) {
+    auto d = ShortDuration::from_microseconds(std::numeric_limits<int64_t>::min());
+    EXPECT_EQ(d, ShortDuration::min());
+}
+
+TEST_F(DurationTest, ShortDurationFromMilliseconds) {
+    auto d = ShortDuration::from_milliseconds(3);
+    EXPECT_EQ(d.picoseconds(), 3 * ONE_MS_PICOS);
+}
+
+TEST_F(DurationTest, ShortDurationFromMillisecondsNegative) {
+    auto d = ShortDuration::from_milliseconds(-3);
+    EXPECT_EQ(d.picoseconds(), -3 * ONE_MS_PICOS);
+}
+
+TEST_F(DurationTest, ShortDurationFromMillisecondsOverflowSaturates) {
+    auto d = ShortDuration::from_milliseconds(std::numeric_limits<int64_t>::max());
+    EXPECT_EQ(d, ShortDuration::max());
+}
+
+TEST_F(DurationTest, ShortDurationFromMillisecondsUnderflowSaturates) {
+    auto d = ShortDuration::from_milliseconds(std::numeric_limits<int64_t>::min());
+    EXPECT_EQ(d, ShortDuration::min());
+}
+
+TEST_F(DurationTest, ShortDurationFromMillisecondsBoundary) {
+    // MAX_SAFE_MS = INT64_MAX / 10^9 = 9'223'372'036 (ms)
+    constexpr int64_t MAX_SAFE_MS = std::numeric_limits<int64_t>::max() / ONE_MS_PICOS;
+    auto at_max = ShortDuration::from_milliseconds(MAX_SAFE_MS);
+    EXPECT_FALSE(saturated(at_max));
+    EXPECT_EQ(at_max.picoseconds(), MAX_SAFE_MS * ONE_MS_PICOS);
+
+    auto over_max = ShortDuration::from_milliseconds(MAX_SAFE_MS + 1);
+    EXPECT_EQ(over_max, ShortDuration::max());
+
+    constexpr int64_t MIN_SAFE_MS = std::numeric_limits<int64_t>::min() / ONE_MS_PICOS;
+    auto at_min = ShortDuration::from_milliseconds(MIN_SAFE_MS);
+    EXPECT_FALSE(saturated(at_min));
+    EXPECT_EQ(at_min.picoseconds(), MIN_SAFE_MS * ONE_MS_PICOS);
+
+    auto under_min = ShortDuration::from_milliseconds(MIN_SAFE_MS - 1);
+    EXPECT_EQ(under_min, ShortDuration::min());
+}
+
+TEST_F(DurationTest, ShortDurationFromSeconds) {
+    auto d = ShortDuration::from_seconds(int64_t{2});
+    EXPECT_EQ(d.picoseconds(), 2 * ONE_SECOND_PICOS);
+}
+
+TEST_F(DurationTest, ShortDurationFromSecondsNegative) {
+    auto d = ShortDuration::from_seconds(int64_t{-5});
+    EXPECT_EQ(d.picoseconds(), -5 * ONE_SECOND_PICOS);
+}
+
+TEST_F(DurationTest, ShortDurationFromSecondsEquivalentToPicoseconds) {
+    // Sanity check: the new factory produces the same value as the manual pattern
+    // callers had to write before.
+    EXPECT_EQ(ShortDuration::from_seconds(int64_t{1}),
+              ShortDuration::from_picoseconds(ONE_SECOND_PICOS));
+    EXPECT_EQ(ShortDuration::from_seconds(int64_t{-3}),
+              ShortDuration::from_picoseconds(-3 * ONE_SECOND_PICOS));
+}
+
+TEST_F(DurationTest, ShortDurationFromSecondsOverflowSaturates) {
+    auto d = ShortDuration::from_seconds(std::numeric_limits<int64_t>::max());
+    EXPECT_EQ(d, ShortDuration::max());
+    EXPECT_TRUE(saturated(d));
+}
+
+TEST_F(DurationTest, ShortDurationFromSecondsUnderflowSaturates) {
+    auto d = ShortDuration::from_seconds(std::numeric_limits<int64_t>::min());
+    EXPECT_EQ(d, ShortDuration::min());
+    EXPECT_TRUE(saturated(d));
+}
+
+TEST_F(DurationTest, ShortDurationFromSecondsBoundary) {
+    // ShortDuration stores int64_t picoseconds (~±106 days).
+    // MAX_SAFE_S = INT64_MAX / 10^12 = 9'223'372 (seconds ≈ 106.75 days).
+    constexpr int64_t MAX_SAFE_S = std::numeric_limits<int64_t>::max() / ONE_SECOND_PICOS;
+    auto at_max = ShortDuration::from_seconds(MAX_SAFE_S);
+    EXPECT_FALSE(saturated(at_max));
+    EXPECT_EQ(at_max.picoseconds(), MAX_SAFE_S * ONE_SECOND_PICOS);
+
+    auto over_max = ShortDuration::from_seconds(MAX_SAFE_S + 1);
+    EXPECT_EQ(over_max, ShortDuration::max());
+
+    constexpr int64_t MIN_SAFE_S = std::numeric_limits<int64_t>::min() / ONE_SECOND_PICOS;
+    auto at_min = ShortDuration::from_seconds(MIN_SAFE_S);
+    EXPECT_FALSE(saturated(at_min));
+    EXPECT_EQ(at_min.picoseconds(), MIN_SAFE_S * ONE_SECOND_PICOS);
+
+    auto under_min = ShortDuration::from_seconds(MIN_SAFE_S - 1);
+    EXPECT_EQ(under_min, ShortDuration::min());
+}
+
+TEST_F(DurationTest, ShortDurationConstexprFactoryKnownSafe) {
+    constexpr auto d1 = ShortDuration::from_seconds(int64_t{1});
+    constexpr auto d2 = ShortDuration::from_milliseconds(int64_t{1000});
+    constexpr auto d3 = ShortDuration::from_microseconds(int64_t{1'000'000});
+    constexpr auto d4 = ShortDuration::from_nanoseconds(int64_t{1'000'000'000});
+
+    EXPECT_EQ(d1.picoseconds(), ONE_SECOND_PICOS);
+    EXPECT_EQ(d2.picoseconds(), ONE_SECOND_PICOS);
+    EXPECT_EQ(d3.picoseconds(), ONE_SECOND_PICOS);
+    EXPECT_EQ(d4.picoseconds(), ONE_SECOND_PICOS);
+}
+
 TEST_F(DurationTest, ShortDurationNegative) {
     auto d = ShortDuration::from_picoseconds(-500'000'000'000); // -0.5 seconds
     EXPECT_EQ(d.picoseconds(), -500'000'000'000);

--- a/tests/timestamp_test.cpp
+++ b/tests/timestamp_test.cpp
@@ -1073,7 +1073,7 @@ TEST_F(TimestampTest, SubtractShortDuration) {
 
 TEST_F(TimestampTest, AddShortDurationOperator) {
     UtcRealTimestamp ts(100, 0);
-    auto sd = ShortDuration::from_picoseconds(2'000'000'000'000); // 2 seconds
+    auto sd = ShortDuration::from_seconds(2);
 
     auto result = ts + sd;
     EXPECT_EQ(result.tsi(), 102);
@@ -1091,7 +1091,7 @@ TEST_F(TimestampTest, SubtractShortDurationOperator) {
 
 TEST_F(TimestampTest, AddNegativeShortDuration) {
     UtcRealTimestamp ts(100, 500'000'000'000ULL);
-    auto sd = ShortDuration::from_picoseconds(-1'000'000'000'000); // -1 second
+    auto sd = ShortDuration::from_seconds(-1);
 
     ts += sd;
     EXPECT_EQ(ts.tsi(), 99);
@@ -1100,7 +1100,7 @@ TEST_F(TimestampTest, AddNegativeShortDuration) {
 
 TEST_F(TimestampTest, ShortDurationOverflowSaturates) {
     UtcRealTimestamp ts(UINT32_MAX - 1, 500'000'000'000ULL);
-    auto sd = ShortDuration::from_picoseconds(2'000'000'000'000); // 2 seconds - will overflow
+    auto sd = ShortDuration::from_seconds(2); // will overflow
 
     ts += sd;
     // Should saturate to max timestamp
@@ -1110,7 +1110,7 @@ TEST_F(TimestampTest, ShortDurationOverflowSaturates) {
 
 TEST_F(TimestampTest, ShortDurationUnderflowSaturates) {
     UtcRealTimestamp ts(1, 500'000'000'000ULL);
-    auto sd = ShortDuration::from_picoseconds(3'000'000'000'000); // 3 seconds - will underflow
+    auto sd = ShortDuration::from_seconds(3); // will underflow
 
     ts -= sd;
     // Should saturate to zero


### PR DESCRIPTION
Closes #58.

## Summary
- Adds `from_seconds`, `from_milliseconds`, `from_microseconds`, `from_nanoseconds` to `ShortDuration`, matching `Duration`'s API.
- Each factory saturates to `ShortDuration::max()` / `ShortDuration::min()` on overflow/underflow via pre-check against `INT64_MAX` / `INT64_MIN`, matching the existing `Duration` contract.
- Unlike `Duration::from_seconds` (which only clamps to `int32_t` and never multiplies), `ShortDuration::from_seconds` multiplies by `10^12`, so it uses the same overflow shape as the other sub-second factories.
- Simplifies four whole-second `ShortDuration::from_picoseconds(N'000'000'000'000)` call sites in `tests/timestamp_test.cpp` to `from_seconds(N)`.

## Scope
In scope (per issue):
- Four `int64_t` unit factories with saturation.
- Positive, negative, overflow, underflow, and boundary tests.

Out of scope (per issue):
- User-defined literals (`1_s`, `500_ms`).
- `from_seconds(double)` checked variant — issue only asks for `int64_t`.
- Python bindings for `ShortDuration` — not currently exposed to Python.

## Test plan
- [x] New tests added in `tests/duration_test.cpp` cover positive/negative happy paths, INT64_MAX/MIN overflow/underflow, and `MAX_SAFE_*` / `MIN_SAFE_*` boundary behavior for `from_seconds` and `from_milliseconds`.
- [x] Constexpr smoke test confirms all four factories are usable in `constexpr` context.
- [x] `make format-check` passes.
- [x] `make` (Debug build) succeeds.
- [x] `ctest -R '^duration_test$' --output-on-failure` passes.
- [x] `ctest -R '^timestamp_test$' --output-on-failure` passes (exercises the simplified call sites).
- [x] Full `ctest` suite: 54/54 pass.
- [x] `make quick-check` (Release CI gate) passes.