### PR TITLE
chore: clean up release-please config for 0.x release flow

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -9,7 +9,7 @@
         { "type": "generic", "path": "bindings/python/pyproject.toml" }
       ],
       "changelog-path": "CHANGELOG.md",
-      "bump-minor-pre-major": true
+      "bump-minor-pre-major": false
     }
   }
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,7 +4,6 @@
   "packages": {
     ".": {
       "release-type": "simple",
-      "release-as": "0.1.0",
       "extra-files": [
         { "type": "generic", "path": "CMakeLists.txt" },
         { "type": "generic", "path": "bindings/python/pyproject.toml" }


### PR DESCRIPTION
## Summary
Two small `release-please-config.json` fixes so the release flow works correctly going forward:

1. **Remove `release-as: \"0.1.0\"` pin.** 0.1.0 already shipped in #56. Per DEVELOPMENT.md: *\"After the first release: remove `release-as` from `release-please-config.json` so subsequent versions are auto-determined from commit messages.\"* Leaving the pin would keep re-queuing 0.1.0 instead of bumping.

2. **Flip `bump-minor-pre-major` from `true` → `false`.** While pre-1.0, treat `feat:` commits as patch bumps (0.1.0 → 0.1.1) rather than minor bumps (0.1.0 → 0.2.0). Reserve 0.x minor bumps (0.2.0, 0.3.0, ...) for intentional milestone releases cut via `release-as`. More conservative signaling for a young library — one additive helper shouldn't consume a minor version. Once we hit 1.0 this flag stops mattering.

## Why merge this before #59
#59 is a `feat:` change. Without these fixes, it would produce either a stale 0.1.0 Release PR (if the pin is still there) or a 0.2.0 bump that's larger than the change warrants. Merging this first means #59 cleanly produces a 0.1.1 Release PR — which you can then let sit and accumulate more changes before actually cutting a release.

## Test plan
- [x] Config still valid JSON (see diff: only the two target lines changed).
- [ ] After merge, verify the next `feat:`/`fix:` merge opens a Release PR targeting 0.1.1 (will be confirmed when #59 lands).