### PR TITLE
chore: restore release process after 0.2.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,17 +22,7 @@ jobs:
           ref: ${{ inputs.ref || github.sha }}
 
       - name: Check version consistency
-        run: |
-          CMAKE_VER=$(grep -oP 'VERSION \K[0-9]+\.[0-9]+\.[0-9]+' CMakeLists.txt | head -1)
-          PYPROJECT_VER=$(grep -oP '^version = "\K[0-9]+\.[0-9]+\.[0-9]+' bindings/python/pyproject.toml)
-          MANIFEST_VER=$(python3 -c "import json; print(json.load(open('.release-please-manifest.json'))['.'])")
-          echo "CMakeLists.txt:  $CMAKE_VER"
-          echo "pyproject.toml:  $PYPROJECT_VER"
-          echo "manifest.json:   $MANIFEST_VER"
-          if [ "$CMAKE_VER" != "$PYPROJECT_VER" ] || [ "$CMAKE_VER" != "$MANIFEST_VER" ]; then
-            echo "::error::Version mismatch! All three files must agree."
-            exit 1
-          fi
+        run: ./scripts/ci/version-check.sh
 
   format-check:
     runs-on: ubuntu-24.04

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -25,7 +25,9 @@ in three files via `x-release-please-version` markers:
 - `bindings/python/pyproject.toml`
 - `.release-please-manifest.json` (derived mirror)
 
-Do not edit versions manually — the `version-check` CI job fails if they diverge.
+Do not edit versions manually outside a release-please release PR. Run
+`make version-check` locally when touching release files; the `version-check`
+CI job fails if these files diverge or a version marker is removed.
 
 ## Build Commands
 
@@ -46,6 +48,7 @@ PYTHONPATH=build/bindings/python .venv/bin/pytest bindings/python/tests/ -v
 PYTHONPATH=build/bindings/python .venv/bin/pytest bindings/python/tests/test_enums.py -v -k "some_pattern"
 
 # Code quality
+make version-check      # Check release-managed versions (CI gate)
 make format-check       # Check clang-format (CI gate)
 make docs-check         # Check local markdown links
 make format-fix         # Auto-fix formatting
@@ -120,11 +123,29 @@ Type stubs are auto-generated at `build/bindings/python/vrtigo.pyi` by the `vrti
 - **Required gates**: `format-check`, `quick-check`, `version-check`
 - **Advisory**: `static-analysis`, `debug-build`, `clang-build`, `python-bindings`
 - **PR title lint**: PR titles must follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, `chore:`, etc.)
-- Run `make format-check && make quick-check` before pushing
+- Run `make version-check && make format-check && make quick-check` before pushing
+
+### Version Control Workflow
+
+- Work on topic branches named for the change type, such as `feat/...`,
+  `fix/...`, `docs/...`, or `chore/...`.
+- Keep PR titles in Conventional Commit format. With squash merge enabled, the
+  PR title becomes the commit message that release-please reads on `main`.
+- While the project is pre-`1.0.0`, release-please treats `0.x` minor versions
+  as compatibility boundaries: breaking changes bump the minor version and
+  features or fixes bump the patch version.
+- Do not hand-edit `CHANGELOG.md`, `CMakeLists.txt` version, Python package
+  version, or `.release-please-manifest.json` for normal development. Those
+  changes belong in the release-please release PR.
+- Use direct version edits only for release recovery work. If `release-as` is
+  temporarily added to `release-please-config.json`, remove it in the same
+  recovery cycle after the intended release has been created.
 
 ### Release Process
 
-Releases use [release-please](https://github.com/googleapis/release-please) with squash merge on main.
+Releases use [release-please](https://github.com/googleapis/release-please)
+with squash merge on `main`. The first `v0.1.0` bootstrap release is complete;
+future versions are inferred from Conventional Commit messages.
 
 1. **PR titles** follow Conventional Commit format — enforced by the `pr-title-lint` CI check
 2. **Squash merge** PRs to main — the PR title becomes the commit message
@@ -134,6 +155,3 @@ Releases use [release-please](https://github.com/googleapis/release-please) with
 6. Publish workflow: verifies GitHub Release exists → runs CI → builds wheels → uploads to GitHub Release
 7. To also publish to **PyPI**: check the `pypi` checkbox in the workflow dispatch form
 8. If a release PR is not created, confirm the squash commit title is Conventional Commit format and rerun Release Please under GitHub actions.
-
-After the first release: remove `release-as` from `release-please-config.json` so
-subsequent versions are auto-determined from commit messages.

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 .PHONY: all clean configure debug release help check
 .PHONY: test install uninstall autodocs
-.PHONY: quick-check coverage debug-build clang-build install-verify ci-full clean-all
+.PHONY: version-check quick-check coverage debug-build clang-build install-verify ci-full clean-all
 .PHONY: format-check format-fix format-diff docs-check clang-tidy clang-tidy-fix
 .PHONY: python python-test python-stubs python-clean
 .PHONY: gpu-test gpu-syntax-check gpu-install-verify
@@ -85,6 +85,7 @@ check: test
 # Note: Some checks may be skipped if optional dependencies are missing
 ci-full:
 	@echo "Running full CI validation..."
+	@$(MAKE) version-check
 	@$(MAKE) format-check
 	@$(MAKE) docs-check
 	@$(MAKE) quick-check
@@ -100,6 +101,10 @@ ci-full:
 # Run this before every push to ensure CI gate will pass
 quick-check:
 	@./scripts/ci/quick-check.sh build-quick
+
+# Version consistency - matches CI version-check job (required gate)
+version-check:
+	@./scripts/ci/version-check.sh
 
 # Code coverage report - matches CI coverage job
 # Generates HTML report in build-coverage/coverage_html/index.html
@@ -253,6 +258,7 @@ help:
 	@echo "    make coverage            Generate coverage report"
 	@echo ""
 	@echo "  Other CI targets:"
+	@echo "    make version-check       Check release-managed versions"
 	@echo "    make quick-check         Fast validation (Release build)"
 	@echo "    make debug-build         Debug build (catch assertions)"
 	@echo "    make clang-build         Clang compiler test"

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -9,7 +9,8 @@
         { "type": "generic", "path": "bindings/python/pyproject.toml" }
       ],
       "changelog-path": "CHANGELOG.md",
-      "bump-minor-pre-major": false
+      "bump-minor-pre-major": true,
+      "bump-patch-for-minor-pre-major": true
     }
   }
 }

--- a/scripts/ci/README.md
+++ b/scripts/ci/README.md
@@ -15,6 +15,20 @@ These scripts ensure that **local validation and CI validation are identical**:
 
 All scripts take an optional `BUILD_DIR` argument (defaults shown below):
 
+### `version-check.sh` (Required Gate)
+**Matches**: CI `version-check` job
+**Usage**: `./scripts/ci/version-check.sh`
+**What**: Verifies release-managed versions and release-please markers
+**When**: Run before pushing release config or version-touching changes
+
+```bash
+# Direct
+./scripts/ci/version-check.sh
+
+# Via Make
+make version-check
+```
+
 ### `quick-check.sh` (Required Gate)
 **Matches**: CI `quick-check` job (required status)
 **Usage**: `./scripts/ci/quick-check.sh [build-quick]`
@@ -40,7 +54,7 @@ make quick-check
 ./scripts/ci/debug-build.sh
 
 # Via Make
-make ci-debug
+make debug-build
 ```
 
 ### `clang-build.sh` (Advisory)
@@ -57,7 +71,7 @@ make ci-debug
 CXX=clang++-16 ./scripts/ci/clang-build.sh
 
 # Via Make
-make ci-clang
+make clang-build
 ```
 
 ### `install-verify.sh` (Advisory)
@@ -75,7 +89,7 @@ make ci-clang
 ./scripts/ci/install-verify.sh build /tmp/my-install
 
 # Via Make
-make ci-install-verify
+make install-verify
 ```
 
 ### `coverage.sh` (Informational)
@@ -89,7 +103,7 @@ make ci-install-verify
 ./scripts/ci/coverage.sh
 
 # Via Make
-make ci-coverage
+make coverage
 
 # View report
 open build-coverage/coverage_html/index.html
@@ -217,11 +231,13 @@ The `install-verify.sh` script builds a minimal library (tests/benchmarks OFF) t
 
 ### Before pushing
 ```bash
+./scripts/ci/version-check.sh
 ./scripts/ci/quick-check.sh
 ```
 
 ### Full local validation
 ```bash
+./scripts/ci/version-check.sh
 ./scripts/ci/quick-check.sh
 ./scripts/ci/debug-build.sh
 ./scripts/ci/clang-build.sh
@@ -235,6 +251,7 @@ open build-coverage/coverage_html/index.html
 
 ### Before release
 ```bash
+./scripts/ci/version-check.sh
 ./scripts/ci/install-verify.sh
 ```
 

--- a/scripts/ci/version-check.sh
+++ b/scripts/ci/version-check.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Check that release-managed version files agree.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+python3 - <<'PY'
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+
+ROOT = Path.cwd()
+VERSION_RE = re.compile(r"^\d+\.\d+\.\d+$")
+
+
+def read_text(path: str) -> str:
+    return (ROOT / path).read_text(encoding="utf-8")
+
+
+def extract(pattern: str, text: str, label: str) -> str | None:
+    match = re.search(pattern, text, re.MULTILINE | re.DOTALL)
+    if match is None:
+        print(f"Error: could not find version in {label}", file=sys.stderr)
+        return None
+    return match.group(1)
+
+
+cmake_text = read_text("CMakeLists.txt")
+pyproject_text = read_text("bindings/python/pyproject.toml")
+
+versions: dict[str, str | None] = {
+    "CMakeLists.txt": extract(
+        r"project\s*\(\s*vrtigo\b.*?\bVERSION\s+([0-9]+\.[0-9]+\.[0-9]+)",
+        cmake_text,
+        "CMakeLists.txt",
+    ),
+    "bindings/python/pyproject.toml": extract(
+        r'^version\s*=\s*"([^"]+)"',
+        pyproject_text,
+        "bindings/python/pyproject.toml",
+    ),
+}
+
+try:
+    manifest = json.loads(read_text(".release-please-manifest.json"))
+except json.JSONDecodeError as exc:
+    print(f"Error: invalid .release-please-manifest.json: {exc}", file=sys.stderr)
+    sys.exit(1)
+
+manifest_version = manifest.get(".")
+if not isinstance(manifest_version, str):
+    print('Error: .release-please-manifest.json must contain string key "."', file=sys.stderr)
+    manifest_version = None
+versions[".release-please-manifest.json"] = manifest_version
+
+errors: list[str] = []
+for path, version in versions.items():
+    display = version if version is not None else "<missing>"
+    print(f"{path}: {display}")
+    if version is None:
+        errors.append(f"{path}: missing version")
+    elif VERSION_RE.fullmatch(version) is None:
+        errors.append(f"{path}: expected MAJOR.MINOR.PATCH, found {version!r}")
+
+for path, text in {
+    "CMakeLists.txt": cmake_text,
+    "bindings/python/pyproject.toml": pyproject_text,
+}.items():
+    if "x-release-please-version" not in text:
+        errors.append(f"{path}: missing x-release-please-version marker")
+
+present_versions = {version for version in versions.values() if version is not None}
+if len(present_versions) > 1:
+    errors.append("version mismatch: release-managed files must agree")
+
+if errors:
+    print("\nVersion check failed:", file=sys.stderr)
+    for error in errors:
+        print(f"- {error}", file=sys.stderr)
+    sys.exit(1)
+
+print("Version check passed")
+PY


### PR DESCRIPTION
Restores release-please pre-1.0 bump policy and adds shared version-check tooling after v0.2.0. No release impact.