### PR TITLE
fix: decode sample_rate and bandwidth as signed Q44.20 per VITA 49.2

### DIFF
--- a/docs/cif_access.md
+++ b/docs/cif_access.md
@@ -13,7 +13,7 @@ packet[field_tag]  // Returns FieldProxy for the field
 Each field supports a **three-tier access pattern**:
 
 1. **`.bytes()`** - Raw bytes as they appear in the packet (network byte order)
-2. **`.encoded()`** - Structured but uninterpreted value (e.g., Q52.12 fixed-point)
+2. **`.encoded()`** - Structured but uninterpreted value (e.g., fixed-point encoding)
 3. **`.value()`** - Interpreted value with units (Hz, dBm, etc.) - *only for fields with interpretation support*
 
 Example:
@@ -24,7 +24,7 @@ if (packet[sample_rate]) {
     auto raw = packet[sample_rate].bytes();        // std::span<std::byte, 8>
 
     // Tier 2: Encoded value
-    uint64_t encoded = packet[sample_rate].encoded();  // Q52.12 fixed-point
+    uint64_t encoded = packet[sample_rate].encoded();  // Q44.20 fixed-point
 
     // Tier 3: Interpreted value (only for supported fields)
     double hz = packet[sample_rate].value();           // Hertz
@@ -49,7 +49,7 @@ The following fields provide `.value()` methods that return interpreted values w
 |-----|-----|-------|------|----------------|
 | CIF0 | 15 | [Data Payload Format](cif_access/cif0_15_payload_format.md) | `PayloadFormat::View` | Structured bitfield access |
 | CIF0 | 17 | [Device Identifier](cif_access/cif0_17_device_id.md) | `DeviceIdentifier::View` | Manufacturer OUI + device code |
-| CIF0 | 21 | [Sample Rate](cif_access/cif0_21_sample_rate.md) | `double` | Hz (from Q52.12) |
+| CIF0 | 21 | [Sample Rate](cif_access/cif0_21_sample_rate.md) | `double` | Hz (from Q44.20, two's complement) |
 | CIF0 | 22 | [Over-Range Count](cif_access/cif0_22_over_range_count.md) | `uint32_t` | Count of over-range samples |
 | CIF0 | 23 | [Gain](cif_access/cif0_23_gain.md) | `GainValue` | Two-stage gain in dB (from Q9.7) |
 | CIF0 | 24 | [Reference Level](cif_access/cif0_24_reference_level.md) | `double` | dBm (from Q9.7) |
@@ -57,7 +57,7 @@ The following fields provide `.value()` methods that return interpreted values w
 | CIF0 | 26 | [RF Frequency Offset](cif_access/cif0_26_rf_frequency_offset.md) | `double` | Hz (from Q44.20, two's complement) |
 | CIF0 | 27 | [RF Reference Frequency](cif_access/cif0_27_rf_reference_frequency.md) | `double` | Hz (from Q44.20, two's complement) |
 | CIF0 | 28 | [IF Reference Frequency](cif_access/cif0_28_if_reference_frequency.md) | `double` | Hz (from Q44.20, two's complement) |
-| CIF0 | 29 | [Bandwidth](cif_access/cif0_29_bandwidth.md) | `double` | Hz (from Q52.12) |
+| CIF0 | 29 | [Bandwidth](cif_access/cif0_29_bandwidth.md) | `double` | Hz (from Q44.20, two's complement) |
 | CIF0 | 30 | [Reference Point Identifier](cif_access/cif0_30_reference_point_id.md) | `uint32_t` | Stream ID of timing reference point |
 
 
@@ -102,7 +102,7 @@ Both compile-time (`ContextPacketBuilder<>`) and dynamic (`dynamic::ContextPacke
 |--------|----------------------|-----------------|-------------|
 | `bytes()` | ✓ read | ✓ read | Literal on-wire bytes |
 | `set_bytes(span)` | ✓ write | ✗ | Set on-wire bytes in bulk |
-| `encoded()` | ✓ read | ✓ read | Structured format (e.g., Q52.12 as `uint64_t`) |
+| `encoded()` | ✓ read | ✓ read | Structured on-wire format (e.g., fixed-point as `uint64_t`) |
 | `set_encoded(T)` | ✓ write | ✗ | Set structured value |
 | `value()` | ✓ read | ✓ read | Interpreted units (Hz, dBm, etc.) if defined |
 | `set_value(T)` | ✓ write | ✗ | Set interpreted value |

--- a/docs/cif_access/cif0_21_sample_rate.md
+++ b/docs/cif_access/cif0_21_sample_rate.md
@@ -6,7 +6,7 @@
 
 ## Setting and Reading Sample Rate
 
-The Sample Rate field is a 64-bit Q52.12 fixed-point value representing
+The Sample Rate field is a 64-bit two's-complement Q44.20 fixed-point value representing
 the sample rate in Hz. Set and read the encoded value directly.
 
 ```cpp
@@ -21,7 +21,7 @@ the sample rate in Hz. Set and read the encoded value directly.
     // Read back the value in Hz
     double rate_hz = packet[sample_rate].value();
 
-    // Can also access the encoded Q52.12 value directly
+    // Can also access the encoded Q44.20 value directly
     uint64_t encoded = packet[sample_rate].encoded();
 ```
 

--- a/docs/cif_access/cif0_29_bandwidth.md
+++ b/docs/cif_access/cif0_29_bandwidth.md
@@ -6,7 +6,7 @@
 
 ## Setting and Reading Bandwidth
 
-The Bandwidth field is a 64-bit Q52.12 fixed-point value representing
+The Bandwidth field is a 64-bit two's-complement Q44.20 fixed-point value representing
 the signal bandwidth in Hz.
 
 ```cpp
@@ -21,7 +21,7 @@ the signal bandwidth in Hz.
     // Read back the value in Hz
     double bw_hz = packet[bandwidth].value();
 
-    // Can also access the encoded Q52.12 value directly
+    // Can also access the encoded Q44.20 value directly
     uint64_t encoded = packet[bandwidth].encoded();
 ```
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -52,7 +52,7 @@ for system errors so they can integrate cleanly with host I/O abstractions.
 - FieldProxy caches offset, size, presence on creation
 - Three-level access hierarchy:
   - `.bytes()` - on-wire bytes as-is
-  - `.encoded()` - structured format (Q52.12, etc.)
+  - `.encoded()` - structured on-wire format (fixed-point, bitfields, etc.)
   - `.value()` - interpreted values (Hz, dBm) - optional
 - Lazy evaluation - field not read until proxy dereferenced
 - Works for both compile-time and runtime packets

--- a/include/vrtigo/detail/field_proxy.hpp
+++ b/include/vrtigo/detail/field_proxy.hpp
@@ -29,7 +29,7 @@ namespace vrtigo {
  *   auto bw = packet[field::bandwidth];
  *   if (bw) {
  *       auto bytes = bw.bytes();              // Raw on-wire bytes
- *       uint64_t enc = bw.encoded();          // Structured Q52.12 encoding
+ *       uint64_t enc = bw.encoded();          // Structured on-wire encoding
  *       double hz = bw.value();               // Interpreted Hz (if supported)
  *   }
  */
@@ -138,7 +138,7 @@ public:
      * Get structured on-wire field value (FieldTraits::value_type)
      *
      * Returns the field value as decoded by FieldTraits::read().
-     * This is NOT interpreted (e.g., Q52.12 encoding, not Hz).
+     * This is NOT interpreted (e.g., fixed-point encoding, not Hz).
      * For interpreted values (Hz, dBm, etc.), use .value() on fields that support it.
      *
      * @return Structured wire format (uint32_t, uint64_t, FieldView<N>, etc.)
@@ -158,7 +158,7 @@ public:
      * Write structured value to field (mutable packets only)
      *
      * Writes the value using FieldTraits::write().
-     * This writes the raw on-wire format (e.g., Q52.12 encoding).
+     * This writes the raw on-wire format (e.g., fixed-point encoding).
      * For interpreted writes (Hz, dBm, etc.), use .set_value() on fields that support it.
      *
      * @param v Value to write (FieldTraits::value_type)

--- a/include/vrtigo/detail/field_traits.hpp
+++ b/include/vrtigo/detail/field_traits.hpp
@@ -310,15 +310,15 @@ struct FieldTraits<0, 21> {
         cif::write_u64_safe(base, offset, v);
     }
 
-    // Interpreted support: Q52.12 fixed-point → Hz (double)
+    // Interpreted support: Q44.20 fixed-point (two's complement) → Hz (double)
     using interpreted_type = double;
 
     static interpreted_type to_interpreted(value_type raw) noexcept {
-        return FixedPoint<52, 12, false>::to_double(raw);
+        return FixedPoint<44, 20, true>::to_double(raw);
     }
 
     static value_type from_interpreted(interpreted_type hz) noexcept {
-        return FixedPoint<52, 12, false>::from_double(hz);
+        return FixedPoint<44, 20, true>::from_double(hz < 0.0 ? 0.0 : hz);
     }
 };
 
@@ -536,15 +536,15 @@ struct FieldTraits<0, 29> {
         cif::write_u64_safe(base, offset, v);
     }
 
-    // Interpreted support: Q52.12 fixed-point → Hz (double)
+    // Interpreted support: Q44.20 fixed-point (two's complement) → Hz (double)
     using interpreted_type = double;
 
     static interpreted_type to_interpreted(value_type raw) noexcept {
-        return FixedPoint<52, 12, false>::to_double(raw);
+        return FixedPoint<44, 20, true>::to_double(raw);
     }
 
     static value_type from_interpreted(interpreted_type hz) noexcept {
-        return FixedPoint<52, 12, false>::from_double(hz);
+        return FixedPoint<44, 20, true>::from_double(hz < 0.0 ? 0.0 : hz);
     }
 };
 

--- a/tests/cif/CMakeLists.txt
+++ b/tests/cif/CMakeLists.txt
@@ -4,7 +4,7 @@
 # Field Proxy Interface Tests
 vrtigo_add_gtest(proxy_test proxy_test.cpp NAME cif_proxy_test)
 
-# Interpreted Value Tests (Q52.12 ↔ Hz conversion)
+# Interpreted Value Tests (Q44.20 ↔ Hz conversion)
 # Tests bandwidth and sample_rate fields
 vrtigo_add_gtest(value_test value_test.cpp NAME cif_value_test)
 

--- a/tests/cif/proxy_test.cpp
+++ b/tests/cif/proxy_test.cpp
@@ -26,7 +26,7 @@ TEST_F(FieldProxyTest, BasicSetAndGet) {
     alignas(4) std::array<uint8_t, TestContext::size_bytes()> buffer{};
     TestContext packet(buffer);
 
-    // Set bandwidth raw value (Q52.12 format)
+    // Set bandwidth raw value (fixed-point on-wire format)
     packet[bandwidth].set_encoded(20'000'000ULL);
 
     // Get and verify raw value

--- a/tests/cif/value_test.cpp
+++ b/tests/cif/value_test.cpp
@@ -8,9 +8,13 @@ using namespace vrtigo;
 using namespace vrtigo::field;
 
 // =============================================================================
-// Interpreted Value Tests - Q52.12 Fixed-Point ↔ Hz Conversion
+// Interpreted Value Tests - Q44.20 Fixed-Point ↔ Hz Conversion
 // Tests for CIF fields with interpreted support: bandwidth, sample_rate
 // =============================================================================
+
+namespace {
+constexpr uint64_t q44_20_hz(uint64_t hz) noexcept { return hz << 20; }
+} // namespace
 
 class InterpretedValueTest : public ::testing::Test {
 protected:
@@ -26,10 +30,10 @@ TEST_F(InterpretedValueTest, BandwidthInterpretedRead) {
     alignas(4) std::array<uint8_t, TestContext::size_bytes()> buffer{};
     TestContext packet(buffer);
 
-    // Set bandwidth to Q52.12 encoding for 100 MHz
+    // Set bandwidth to Q44.20 encoding for 100 MHz
     // 100 MHz = 100'000'000 Hz
-    // Q52.12: 100'000'000 * 4096 = 409'600'000'000
-    packet[bandwidth].set_encoded(409'600'000'000ULL);
+    // Q44.20: 100'000'000 * 1'048'576 = 104'857'600'000'000
+    packet[bandwidth].set_encoded(q44_20_hz(100'000'000ULL));
 
     // Read interpreted value
     double hz = packet[bandwidth].value();
@@ -47,9 +51,9 @@ TEST_F(InterpretedValueTest, BandwidthInterpretedWrite) {
     // Write interpreted value (50 MHz)
     packet[bandwidth].set_value(50'000'000.0);
 
-    // Verify raw value is correct Q52.12 encoding
-    // 50 MHz * 4096 = 204'800'000'000
-    EXPECT_EQ(packet[bandwidth].encoded(), 204'800'000'000ULL);
+    // Verify raw value is correct Q44.20 encoding
+    // 50 MHz * 1'048'576 = 52'428'800'000'000
+    EXPECT_EQ(packet[bandwidth].encoded(), q44_20_hz(50'000'000ULL));
 }
 
 TEST_F(InterpretedValueTest, BandwidthRoundTrip) {
@@ -97,10 +101,10 @@ TEST_F(InterpretedValueTest, BandwidthConversionPrecision) {
     alignas(4) std::array<uint8_t, TestContext::size_bytes()> buffer{};
     TestContext packet(buffer);
 
-    // Test Q52.12 conversion accuracy
+    // Test Q44.20 conversion accuracy
 
-    // Test 1: Exact value (divisible by 4096)
-    double exact_hz = 4096.0 * 1000.0; // 4'096'000 Hz
+    // Test 1: Exact integer-Hz value
+    double exact_hz = 4'096'000.0;
     packet[bandwidth].set_value(exact_hz);
     EXPECT_DOUBLE_EQ(packet[bandwidth].value(), exact_hz);
 
@@ -108,8 +112,8 @@ TEST_F(InterpretedValueTest, BandwidthConversionPrecision) {
     double inexact_hz = 1'234'567.89;
     packet[bandwidth].set_value(inexact_hz);
     double retrieved = packet[bandwidth].value();
-    // Should be within Q52.12 resolution (~0.244 Hz)
-    EXPECT_NEAR(retrieved, inexact_hz, 0.25);
+    // Should be within Q44.20 resolution (~0.95 microHz)
+    EXPECT_NEAR(retrieved, inexact_hz, 0.000001);
 }
 
 TEST_F(InterpretedValueTest, BandwidthEdgeCases) {
@@ -123,12 +127,21 @@ TEST_F(InterpretedValueTest, BandwidthEdgeCases) {
     EXPECT_EQ(packet[bandwidth].encoded(), 0ULL);
     EXPECT_DOUBLE_EQ(packet[bandwidth].value(), 0.0);
 
-    // Maximum Q52.12 value
-    uint64_t max_q52_12 = 0xFFFFFFFFFFFFFFFFULL;
-    packet[bandwidth].set_encoded(max_q52_12);
-    EXPECT_EQ(packet[bandwidth].encoded(), max_q52_12);
-    double expected_hz = static_cast<double>(max_q52_12) / 4096.0;
+    // Maximum positive Q44.20 value
+    uint64_t max_q44_20 = 0x7FFFFFFFFFFFFFFFULL;
+    packet[bandwidth].set_encoded(max_q44_20);
+    EXPECT_EQ(packet[bandwidth].encoded(), max_q44_20);
+    double expected_hz = static_cast<double>(max_q44_20) / 1'048'576.0;
     EXPECT_NEAR(packet[bandwidth].value(), expected_hz, 1.0);
+
+    // Raw signed negative values decode as signed Q44.20.
+    packet[bandwidth].set_encoded(0xFFFFFFFFFFFFFFFFULL);
+    EXPECT_NEAR(packet[bandwidth].value(), -1.0 / 1'048'576.0, 1e-12);
+
+    // Interpreted writes clamp negative bandwidths to zero.
+    packet[bandwidth].set_value(-1.0);
+    EXPECT_EQ(packet[bandwidth].encoded(), 0ULL);
+    EXPECT_DOUBLE_EQ(packet[bandwidth].value(), 0.0);
 }
 
 // =============================================================================
@@ -141,10 +154,10 @@ TEST_F(InterpretedValueTest, SampleRateInterpretedRead) {
     alignas(4) std::array<uint8_t, TestContext::size_bytes()> buffer{};
     TestContext packet(buffer);
 
-    // Set sample rate to Q52.12 encoding for 50 MHz (50 MSPS)
+    // Set sample rate to Q44.20 encoding for 50 MHz (50 MSPS)
     // 50 MHz = 50'000'000 Hz
-    // Q52.12: 50'000'000 * 4096 = 204'800'000'000
-    packet[sample_rate].set_encoded(204'800'000'000ULL);
+    // Q44.20: 50'000'000 * 1'048'576 = 52'428'800'000'000
+    packet[sample_rate].set_encoded(q44_20_hz(50'000'000ULL));
 
     // Read interpreted value
     double hz = packet[sample_rate].value();
@@ -162,9 +175,9 @@ TEST_F(InterpretedValueTest, SampleRateInterpretedWrite) {
     // Write interpreted value (25 MSPS)
     packet[sample_rate].set_value(25'000'000.0);
 
-    // Verify raw value is correct Q52.12 encoding
-    // 25 MHz * 4096 = 102'400'000'000
-    EXPECT_EQ(packet[sample_rate].encoded(), 102'400'000'000ULL);
+    // Verify raw value is correct Q44.20 encoding
+    // 25 MHz * 1'048'576 = 26'214'400'000'000
+    EXPECT_EQ(packet[sample_rate].encoded(), q44_20_hz(25'000'000ULL));
 }
 
 TEST_F(InterpretedValueTest, SampleRateRoundTrip) {
@@ -213,10 +226,10 @@ TEST_F(InterpretedValueTest, SampleRateConversionPrecision) {
     alignas(4) std::array<uint8_t, TestContext::size_bytes()> buffer{};
     TestContext packet(buffer);
 
-    // Test Q52.12 conversion accuracy
+    // Test Q44.20 conversion accuracy
 
-    // Test 1: Exact value (divisible by 4096)
-    double exact_hz = 4096.0 * 1000.0; // 4'096'000 Hz
+    // Test 1: Exact integer-Hz value
+    double exact_hz = 4'096'000.0;
     packet[sample_rate].set_value(exact_hz);
     EXPECT_DOUBLE_EQ(packet[sample_rate].value(), exact_hz);
 
@@ -224,8 +237,8 @@ TEST_F(InterpretedValueTest, SampleRateConversionPrecision) {
     double inexact_hz = 12'345'678.9;
     packet[sample_rate].set_value(inexact_hz);
     double retrieved = packet[sample_rate].value();
-    // Should be within Q52.12 resolution (~0.244 Hz)
-    EXPECT_NEAR(retrieved, inexact_hz, 0.25);
+    // Should be within Q44.20 resolution (~0.95 microHz)
+    EXPECT_NEAR(retrieved, inexact_hz, 0.000001);
 }
 
 TEST_F(InterpretedValueTest, SampleRateTypicalADCRates) {
@@ -265,17 +278,26 @@ TEST_F(InterpretedValueTest, SampleRateEdgeCases) {
     EXPECT_EQ(packet[sample_rate].encoded(), 0ULL);
     EXPECT_DOUBLE_EQ(packet[sample_rate].value(), 0.0);
 
-    // Maximum Q52.12 value
-    uint64_t max_q52_12 = 0xFFFFFFFFFFFFFFFFULL;
-    packet[sample_rate].set_encoded(max_q52_12);
-    EXPECT_EQ(packet[sample_rate].encoded(), max_q52_12);
-    double expected_hz = static_cast<double>(max_q52_12) / 4096.0;
+    // Maximum positive Q44.20 value
+    uint64_t max_q44_20 = 0x7FFFFFFFFFFFFFFFULL;
+    packet[sample_rate].set_encoded(max_q44_20);
+    EXPECT_EQ(packet[sample_rate].encoded(), max_q44_20);
+    double expected_hz = static_cast<double>(max_q44_20) / 1'048'576.0;
     EXPECT_NEAR(packet[sample_rate].value(), expected_hz, 1.0);
+
+    // Raw signed negative values decode as signed Q44.20.
+    packet[sample_rate].set_encoded(0xFFFFFFFFFFFFFFFFULL);
+    EXPECT_NEAR(packet[sample_rate].value(), -1.0 / 1'048'576.0, 1e-12);
+
+    // Interpreted writes clamp negative sample rates to zero.
+    packet[sample_rate].set_value(-1.0);
+    EXPECT_EQ(packet[sample_rate].encoded(), 0ULL);
+    EXPECT_DOUBLE_EQ(packet[sample_rate].value(), 0.0);
 
     // Very low sample rate (1 Hz - theoretical minimum)
     packet[sample_rate].set_value(1.0);
     double retrieved = packet[sample_rate].value();
-    EXPECT_NEAR(retrieved, 1.0, 0.25); // Within Q52.12 resolution
+    EXPECT_NEAR(retrieved, 1.0, 0.000001); // Within Q44.20 resolution
 }
 
 // =============================================================================

--- a/tests/cif/value_test.cpp
+++ b/tests/cif/value_test.cpp
@@ -13,7 +13,9 @@ using namespace vrtigo::field;
 // =============================================================================
 
 namespace {
-constexpr uint64_t q44_20_hz(uint64_t hz) noexcept { return hz << 20; }
+constexpr uint64_t q44_20_hz(uint64_t hz) noexcept {
+    return hz << 20;
+}
 } // namespace
 
 class InterpretedValueTest : public ::testing::Test {

--- a/tests/cif_access/cif0_21_sample_rate_test.cpp
+++ b/tests/cif_access/cif0_21_sample_rate_test.cpp
@@ -18,7 +18,7 @@ TEST_F(ContextPacketTest, CIF0_21_BasicAccess) {
     // [/EXAMPLE]
 
     // [DESCRIPTION]
-    // The Sample Rate field is a 64-bit Q52.12 fixed-point value representing
+    // The Sample Rate field is a 64-bit two's-complement Q44.20 fixed-point value representing
     // the sample rate in Hz. Set and read the encoded value directly.
     // [/DESCRIPTION]
 
@@ -34,11 +34,22 @@ TEST_F(ContextPacketTest, CIF0_21_BasicAccess) {
     // Read back the value in Hz
     double rate_hz = packet[sample_rate].value();
 
-    // Can also access the encoded Q52.12 value directly
+    // Can also access the encoded Q44.20 value directly
     uint64_t encoded = packet[sample_rate].encoded();
     // [/SNIPPET]
 
     // Assertions
     EXPECT_DOUBLE_EQ(rate_hz, 10'000'000.0);
-    EXPECT_EQ(encoded >> 12, 10'000'000ULL);
+    EXPECT_EQ(encoded, 10'000'000ULL << 20);
+}
+
+TEST_F(ContextPacketTest, CIF0_21_RawQ44_20Decode) {
+    using SampleRateContext = typed::ContextPacketBuilder<NoTimestamp, NoClassId, sample_rate>;
+
+    alignas(4) std::array<uint8_t, SampleRateContext::size_bytes()> buffer{};
+    SampleRateContext packet(buffer);
+
+    // 50 MHz encoded with radix point 20 must decode to 50 MHz, not 12.8 GHz.
+    packet[sample_rate].set_encoded(50'000'000ULL << 20);
+    EXPECT_DOUBLE_EQ(packet[sample_rate].value(), 50'000'000.0);
 }

--- a/tests/cif_access/cif0_29_bandwidth_test.cpp
+++ b/tests/cif_access/cif0_29_bandwidth_test.cpp
@@ -18,7 +18,7 @@ TEST_F(ContextPacketTest, CIF0_29_BasicAccess) {
     // [/EXAMPLE]
 
     // [DESCRIPTION]
-    // The Bandwidth field is a 64-bit Q52.12 fixed-point value representing
+    // The Bandwidth field is a 64-bit two's-complement Q44.20 fixed-point value representing
     // the signal bandwidth in Hz.
     // [/DESCRIPTION]
 
@@ -34,11 +34,22 @@ TEST_F(ContextPacketTest, CIF0_29_BasicAccess) {
     // Read back the value in Hz
     double bw_hz = packet[bandwidth].value();
 
-    // Can also access the encoded Q52.12 value directly
+    // Can also access the encoded Q44.20 value directly
     uint64_t encoded = packet[bandwidth].encoded();
     // [/SNIPPET]
 
     // Assertions
     EXPECT_DOUBLE_EQ(bw_hz, 20'000'000.0);
-    EXPECT_EQ(encoded >> 12, 20'000'000ULL);
+    EXPECT_EQ(encoded, 20'000'000ULL << 20);
+}
+
+TEST_F(ContextPacketTest, CIF0_29_RawQ44_20Decode) {
+    using BandwidthContext = typed::ContextPacketBuilder<NoTimestamp, NoClassId, bandwidth>;
+
+    alignas(4) std::array<uint8_t, BandwidthContext::size_bytes()> buffer{};
+    BandwidthContext packet(buffer);
+
+    // 100 MHz encoded with radix point 20 must decode to 100 MHz, not 25.6 GHz.
+    packet[bandwidth].set_encoded(100'000'000ULL << 20);
+    EXPECT_DOUBLE_EQ(packet[bandwidth].value(), 100'000'000.0);
 }

--- a/tests/field_access_test.cpp
+++ b/tests/field_access_test.cpp
@@ -64,12 +64,12 @@ int main() {
 
     // =======================================================================
     // Test make_field_proxy_unchecked() for known field (compile-time packets only)
-    // make_field_proxy_unchecked() returns raw values (Q52.12 for bandwidth)
+    // make_field_proxy_unchecked() returns raw values (Q44.20 for bandwidth)
     // =======================================================================
 
     [[maybe_unused]] uint64_t bw_direct = make_field_proxy_unchecked(packet, bandwidth);
-    // 1 MHz in Q52.12 format = 1'000'000 * 4096 = 4'096'000'000
-    assert(bw_direct == 4'096'000'000ULL &&
+    // 1 MHz in Q44.20 format = 1'000'000 * 1'048'576
+    assert(bw_direct == (1'000'000ULL << 20) &&
            "make_field_proxy_unchecked should return correct raw value");
 
     std::cout << "✓ All field access API tests passed!\n";


### PR DESCRIPTION
## Summary

Fix sample_rate (CIF0[21]) and bandwidth (CIF0[29]) interpreted-value conversion. Both were decoded as unsigned Q52.12, but VITA 49.2 §9.5.12 and §9.5.1 specify a 64-bit two's-complement format with the radix point to the right of bit 20 (Q44.20). A 50 MHz wire-encoded sample rate was being reported as 12.8 GHz (50e6 × 2^20 / 2^12).

Closes #62.

## Changes

- `field_traits.hpp` CIF0[21] and CIF0[29]: switch interpreted conversion from `FixedPoint<52, 12, false>` to `FixedPoint<44, 20, true>`.
- `set_value()` for both fields clamps negative interpreted inputs to 0. Per VITA 49.2 §9.5.1 Observation 9.5.1-3 and §9.5.12 Observation 9.5.12-1, negative bandwidth and sample-rate values are not valid. The other Q44.20 fields (IF band offset, RF/IF reference frequency, RF frequency offset) legitimately permit negative values and remain unclamped.
- Updated docs (`cif_access.md`, per-field pages) and tests to reflect the Q44.20 encoding. Added regression tests that pin the failure mode from #62: a radix-20 wire value of 50 MHz must decode to 50 MHz.
- Stale Q52.12 references in unrelated comments cleaned up.

## Spec validation of adjacent interpreted fields

While diagnosing #62, the other interpreted CIF0 fields were cross-checked against VITA 49.2 §9.5 and confirmed to already match spec — no changes needed:

- Reference Level (CIF0[24], §9.5.9): lower 16 bits Q9.7 two's-complement dBm, upper 16 bits reserved=0. VRTigo reads only low 16, clears upper 16 on write.
- IF Band Offset (CIF0[25], §9.5.4): 64-bit two's-complement, radix-20.
- RF Frequency Offset (CIF0[26], §9.5.11): 64-bit two's-complement, radix-20.
- RF Reference Frequency (CIF0[27], §9.5.10): 64-bit two's-complement, radix-20.
- IF Reference Frequency (CIF0[28], §9.5.5): 64-bit two's-complement, radix-20.
- Gain (CIF0[23], §9.5.3): two Q9.7 two's-complement subfields, stage 1 low / stage 2 high.

## Test plan

- [x] `cif_value_test`, `cif_proxy_test` pass
- [x] `cif0_21_sample_rate_test`, `cif0_29_bandwidth_test` pass, including new `RawQ44_20Decode` regression
- [x] Full ctest suite (54 tests) passes
- [x] No in-tree downstream callers write pre-shifted Q52.12 values: no `set_encoded()` use on `sample_rate`/`bandwidth` outside the tests in this PR; Python bindings (`bindings/python/src/vrtigo_module.cpp`) don't expose either field; `examples/` is Python-only and doesn't write VITA fields directly.