### PR TITLE
fix: build release wheels on manylinux_2_28 and require numpy>=2.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -59,7 +59,9 @@ jobs:
           ref: ${{ needs.resolve-tag.outputs.tag }}
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.22
+        # Keep the cibuildwheel version and manylinux image tags below in sync with
+        # .github/workflows/wheel-smoke.yml, which exercises this same release build path.
+        uses: pypa/cibuildwheel@v4.1.0
         with:
           package-dir: bindings/python
           output-dir: wheelhouse
@@ -67,6 +69,14 @@ jobs:
           CIBW_BUILD: "cp311-manylinux* cp312-manylinux* cp313-manylinux*"
           CIBW_SKIP: "*-musllinux*"
           CIBW_ARCHS_LINUX: ${{ matrix.arch }}
+          # numpy ships only manylinux_2_28 wheels since 2.3.0; build on that baseline so the
+          # build env installs a prebuilt numpy instead of source-building it.
+          CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
+          CIBW_MANYLINUX_AARCH64_IMAGE: manylinux_2_28
+          # Import-test each built wheel (deps, incl. numpy>=2.0, are installed from the wheel)
+          # so we never upload a wheel that builds but can't import or run the ndarray path.
+          CIBW_TEST_REQUIRES: pytest>=8.0
+          CIBW_TEST_COMMAND: "pytest {package}/tests"
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/wheel-smoke.yml
+++ b/.github/workflows/wheel-smoke.yml
@@ -1,0 +1,56 @@
+name: wheel-smoke
+
+# Advisory PR check: builds and import-tests a single-interpreter release wheel in the
+# manylinux_2_28 container so wheel packaging / install / import regressions surface on the PR
+# instead of at publish time. This exercises the same build path as publish.yml (which builds
+# the full matrix); keep the cibuildwheel version and manylinux image tags in the two files in
+# sync.
+#
+# MUST STAY ADVISORY (non-required). Because this workflow is path-filtered, a PR that does not
+# touch the paths below skips it entirely. A *required* status check that is skipped stays
+# perpetually "pending" and blocks merge:
+#   https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#onpushpull_requestpull_request_targetpathspaths-ignore
+# To make it a required check, first refactor to an always-running workflow with an internal
+# paths filter (e.g. dorny/paths-filter) plus an always-present aggregate result job.
+
+on:
+  pull_request:
+    paths:
+      - "bindings/python/**"
+      - "include/**"
+      - "CMakeLists.txt"
+      - "cmake/**"
+      - ".github/workflows/publish.yml"
+      - ".github/workflows/wheel-smoke.yml"
+
+jobs:
+  smoke:
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x86_64
+            runner: ubuntu-24.04
+          - arch: aarch64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build + import-test wheel
+        # Keep the cibuildwheel version and manylinux image tags in sync with
+        # .github/workflows/publish.yml.
+        uses: pypa/cibuildwheel@v4.1.0
+        with:
+          package-dir: bindings/python
+          output-dir: wheelhouse
+        env:
+          CIBW_BUILD: "cp312-manylinux*"
+          CIBW_SKIP: "*-musllinux*"
+          CIBW_ARCHS_LINUX: ${{ matrix.arch }}
+          CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
+          CIBW_MANYLINUX_AARCH64_IMAGE: manylinux_2_28
+          CIBW_TEST_REQUIRES: pytest>=8.0
+          CIBW_TEST_COMMAND: "pytest {package}/tests"

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -117,11 +117,11 @@ Type stubs are auto-generated at `build/bindings/python/vrtigo.pyi` by the `vrti
 ### Dependencies
 - Core library: zero external dependencies (header-only)
 - Tests: GoogleTest v1.14.0 (auto-fetched via FetchContent)
-- Python: nanobind v2.4.0, scikit-build-core, Python 3.11+
+- Python: nanobind v2.4.0, scikit-build-core, numpy ≥2.0, Python 3.11+
 
 ### CI Pipeline (GitHub Actions)
 - **Required gates**: `format-check`, `quick-check`, `version-check`
-- **Advisory**: `static-analysis`, `debug-build`, `clang-build`, `python-bindings`
+- **Advisory**: `static-analysis`, `debug-build`, `clang-build`, `python-bindings`, `wheel-smoke` (real cibuildwheel `manylinux_2_28` wheel build + import-test on PRs touching the bindings/build; must stay advisory — see `.github/workflows/wheel-smoke.yml`)
 - **PR title lint**: PR titles must follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, `chore:`, etc.)
 - Run `make version-check && make format-check && make quick-check` before pushing
 

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["scikit-build-core>=0.10", "nanobind>=2.4.0", "numpy>=1.24"]
+requires = ["scikit-build-core>=0.10", "nanobind>=2.4.0", "numpy>=2.0"]
 build-backend = "scikit_build_core.build"
 
 [tool.scikit-build]
@@ -12,7 +12,7 @@ name = "vrtigo"
 version = "0.3.0" # x-release-please-version
 description = "Python bindings for VRTIGO VRT library"
 requires-python = ">=3.11"
-dependencies = ["numpy>=1.24"]
+dependencies = ["numpy>=2.0"]
 
 [project.optional-dependencies]
 dev = ["pytest>=8.0"]


### PR DESCRIPTION
## Problem

The `publish.yml` release wheel build is broken. It pinned `pypa/cibuildwheel@v2.22`, whose default Linux image is **manylinux2014** (glibc 2.17). Inside each wheel build, scikit-build-core's isolated PEP 517 build env installs numpy, and pip (unrestricted) picks the **newest Python-compatible** numpy — **2.4.x for cp311** (numpy 2.5.0 dropped Python 3.11), **2.5.x for cp312/cp313**. Since numpy **2.3.0** those ship **only `manylinux_2_28` wheels**, so pip falls back to building numpy from its **sdist** in the manylinux2014 container, which fails on the container's old toolchain.

Precise mechanism: pip selects the newest candidate and source-builds it — not "no compatible wheel exists" (older numpy ≤2.2.6 still has manylinux2014 wheels, but pip won't downgrade).

nanobind's `nb::ndarray<nb::numpy,…>` is DLPack/buffer-protocol based — the extension has **no numpy C-ABI coupling** — so numpy only needs to install and import in the container. Moving to `manylinux_2_28` gives a prebuilt numpy wheel and fixes the build; no version cap or constraint file is needed.

## Changes

- **`publish.yml`**: `cibuildwheel@v2.22 → @v4.1.0` (defaults to `manylinux_2_28`), explicit `CIBW_MANYLINUX_{X86_64,AARCH64}_IMAGE: manylinux_2_28`, and import-test each built wheel via `CIBW_TEST_REQUIRES: pytest>=8.0` + `CIBW_TEST_COMMAND: pytest {package}/tests` so we never upload a wheel that can't import/run the ndarray path.
- **`pyproject.toml`**: `numpy>=2.0` for build + runtime (no upper cap).
- **`.github/workflows/wheel-smoke.yml`** (new): **advisory** PR check that builds + import-tests a real `cp312` wheel on both native arches (`x86_64`, `aarch64`) in the `manylinux_2_28` container, path-filtered to bindings/build inputs. Mirrors the release path so this class of failure surfaces on PRs instead of at publish time. Must stay advisory (a skipped path-filtered required check would deadlock merge — documented in the workflow header).
- **`DEVELOPMENT.md`**: document numpy ≥2.0 and the new advisory gate.

## Verification

- `numpy>=2.0` resolves to prebuilt `manylinux_2_28` wheels for every target (`cp311→2.4.6`, `cp312/13→2.5.1`) — no source build.
- Editable build + **205 tests pass** under `numpy>=2.0`.
- **Real container build** (`cibuildwheel==4.1.0`, `manylinux_2_28_x86_64`): produced `vrtigo-…-manylinux_2_28_x86_64.whl` and its in-container import-test ran **205 tests, all passed**, exit 0.

## Release note

This is a `fix:` so release-please will cut **v0.3.1**; run **Actions → Publish** with `tag: v0.3.1` afterward to publish the recovered wheels.